### PR TITLE
Making having a fix optional

### DIFF
--- a/devenv/checks/failing_check_with_no_fix.py
+++ b/devenv/checks/failing_check_with_no_fix.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Set
+from typing import Tuple
+
+from devenv.lib_check.types import checker
+
+tags: Set[str] = set(["test", "fail"])
+name = "failing check with no fix"
+
+
+@checker
+def check() -> Tuple[bool, str]:
+    return False, ""

--- a/tests/doctor/devenv/checks/failing_check_with_no_fix.py
+++ b/tests/doctor/devenv/checks/failing_check_with_no_fix.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Set
+from typing import Tuple
+
+from devenv.lib_check.types import checker
+
+tags: Set[str] = set(["test", "fail"])
+name = "failing check with no fix"
+
+
+@checker
+def check() -> Tuple[bool, str]:
+    return False, ""

--- a/tests/doctor/devenv/checks/passing_check_with_no_fix.py
+++ b/tests/doctor/devenv/checks/passing_check_with_no_fix.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Set
+from typing import Tuple
+
+from devenv.lib_check.types import checker
+
+tags: Set[str] = set(["test", "pass"])
+name = "passing check with no fix"
+
+
+@checker
+def check() -> Tuple[bool, str]:
+    return True, ""

--- a/tests/doctor/test_load_checks.py
+++ b/tests/doctor/test_load_checks.py
@@ -25,10 +25,12 @@ def test_load_checks_test_checks(capsys) -> None:  # type: ignore
         set(),
     )
     loaded_check_names = [check.name for check in loaded_checks]
-    assert len(loaded_check_names) == 3
+    assert len(loaded_check_names) == 5
     assert "passing check" in loaded_check_names
     assert "failing check" in loaded_check_names
     assert "failing check with msg" in loaded_check_names
+    assert "passing check with no fix" in loaded_check_names
+    assert "failing check with no fix" in loaded_check_names
     captured = capsys.readouterr()
     assert (
         captured.out
@@ -46,8 +48,9 @@ def test_load_checks_only_passing_tag() -> None:
         {"pass"},
     )
     loaded_check_names = [check.name for check in loaded_checks]
-    assert len(loaded_check_names) == 1
+    assert len(loaded_check_names) == 2
     assert "passing check" in loaded_check_names
+    assert "passing check with no fix" in loaded_check_names
 
 
 def test_load_checks_only_failing_tag() -> None:
@@ -58,9 +61,10 @@ def test_load_checks_only_failing_tag() -> None:
         {"fail"},
     )
     loaded_check_names = [check.name for check in loaded_checks]
-    assert len(loaded_check_names) == 2
+    assert len(loaded_check_names) == 3
     assert "failing check" in loaded_check_names
     assert "failing check with msg" in loaded_check_names
+    assert "failing check with no fix" in loaded_check_names
 
 
 def test_load_checks_passing_and_failing_tag() -> None:
@@ -82,7 +86,9 @@ def test_load_checks_test_tag() -> None:
         {"test"},
     )
     loaded_check_names = [check.name for check in loaded_checks]
-    assert len(loaded_check_names) == 3
+    assert len(loaded_check_names) == 5
     assert "passing check" in loaded_check_names
     assert "failing check" in loaded_check_names
     assert "failing check with msg" in loaded_check_names
+    assert "passing check with no fix" in loaded_check_names
+    assert "failing check with no fix" in loaded_check_names

--- a/tests/doctor/test_run_checks.py
+++ b/tests/doctor/test_run_checks.py
@@ -5,7 +5,9 @@ from concurrent.futures import ThreadPoolExecutor
 from devenv import doctor
 from devenv.tests.doctor.devenv.checks import failing_check
 from devenv.tests.doctor.devenv.checks import failing_check_with_msg
+from devenv.tests.doctor.devenv.checks import failing_check_with_no_fix
 from devenv.tests.doctor.devenv.checks import passing_check
+from devenv.tests.doctor.devenv.checks import passing_check_with_no_fix
 
 
 def test_run_checks_no_checks() -> None:
@@ -46,3 +48,23 @@ def test_run_checks_skip(capsys) -> None:  # type: ignore
     ) == {first_check: (True, "")}
     captured = capsys.readouterr()
     assert captured.out == "    ⏭️  Skipped failing check\n"
+
+
+def test_run_multiple_passing_checks() -> None:
+    first_check = doctor.Check(passing_check)
+    second_check = doctor.Check(passing_check_with_no_fix)
+    assert doctor.run_checks([first_check, second_check], ThreadPoolExecutor()) == {
+        first_check: (True, ""),
+        second_check: (True, ""),
+    }
+
+
+def test_run_multiple_failing_checks() -> None:
+    first_check = doctor.Check(failing_check)
+    second_check = doctor.Check(failing_check_with_msg)
+    third_check = doctor.Check(failing_check_with_no_fix)
+    assert doctor.run_checks([first_check, second_check, third_check], ThreadPoolExecutor()) == {
+        first_check: (False, ""),
+        second_check: (False, "check failed"),
+        third_check: (False, ""),
+    }

--- a/tests/doctor/test_run_checks.py
+++ b/tests/doctor/test_run_checks.py
@@ -50,7 +50,7 @@ def test_run_checks_skip(capsys) -> None:  # type: ignore
     assert captured.out == "    ⏭️  Skipped failing check\n"
 
 
-def test_run_multiple_passing_checks() -> None:
+def test_run_checks_multiple_passing_checks() -> None:
     first_check = doctor.Check(passing_check)
     second_check = doctor.Check(passing_check_with_no_fix)
     assert doctor.run_checks([first_check, second_check], ThreadPoolExecutor()) == {
@@ -59,7 +59,7 @@ def test_run_multiple_passing_checks() -> None:
     }
 
 
-def test_run_multiple_failing_checks() -> None:
+def test_run_checks_multiple_failing_checks() -> None:
     first_check = doctor.Check(failing_check)
     second_check = doctor.Check(failing_check_with_msg)
     third_check = doctor.Check(failing_check_with_no_fix)


### PR DESCRIPTION
Not every check will have an associated fix. This change makes fixers optional and adds logic to handle (auto-skip) checks without fixes.