### PR TITLE
Making devenv python 3.8 compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.8
       - name: "Prepare Artifacts"
         run: |
           pip install build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.8
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        language_version: python3.8
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     rev: v3.12.0
     hooks:
       - id: reorder-python-imports
-        args: [--py311-plus, --add-import, "from __future__ import annotations"]
+        args: [--py38-plus, --add-import, "from __future__ import annotations"]
   - repo: https://github.com/psf/black
     rev: 23.10.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3.8
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 from devenv.constants import CI
 from devenv.constants import home

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
+
 from typing_extensions import TypeAlias
 
 from devenv.constants import CI

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-from functools import cache
+import functools
 
 from devenv.constants import home
 from devenv.constants import shell
 from devenv.lib import proc
 
 
-@cache
+@functools.lru_cache
 def shellrc() -> str:
     if shell == "zsh":
         return f"{home}/.zshrc"
@@ -19,7 +19,7 @@ def shellrc() -> str:
     raise NotImplementedError(f"unsupported shell: {shell}")
 
 
-@cache
+@functools.lru_cache
 def gitroot(cd: str = "") -> str:
     from os.path import normpath, join
 

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 import functools
+import os
 
 from devenv.constants import home
 from devenv.constants import shell

--- a/devenv/lib/proc.py
+++ b/devenv/lib/proc.py
@@ -14,8 +14,6 @@ from devenv.constants import root
 from devenv.constants import shell_path
 from devenv.constants import VOLTA_HOME
 
-Command = tuple[str, ...]
-
 base_path = f"{VOLTA_HOME}/bin:{homebrew_bin}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:{root}/bin"
 base_env = {
     "PATH": base_path,
@@ -25,14 +23,14 @@ base_env = {
 }
 
 
-def quote(cmd: Command) -> str:
+def quote(cmd: tuple[str, ...]) -> str:
     """convert a command to bash-compatible form"""
     from pipes import quote
 
     return " ".join(quote(arg) for arg in cmd)
 
 
-def xtrace(cmd: Command) -> None:
+def xtrace(cmd: tuple[str, ...]) -> None:
     """Print a commandline, similar to how xtrace does."""
 
     teal = "\033[36m"
@@ -44,7 +42,7 @@ def xtrace(cmd: Command) -> None:
 
 @overload
 def run(
-    cmd: Command,
+    cmd: tuple[str, ...],
     *,
     pathprepend: str = "",
     exit: bool = False,
@@ -57,7 +55,7 @@ def run(
 
 @overload
 def run(
-    cmd: Command,
+    cmd: tuple[str, ...],
     *,
     pathprepend: str = "",
     exit: bool = False,
@@ -69,7 +67,7 @@ def run(
 
 
 def run(
-    cmd: Command,
+    cmd: tuple[str, ...],
     *,
     pathprepend: str = "",
     exit: bool = False,

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 from collections.abc import Sequence
 from typing import cast
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 from devenv import bootstrap
 from devenv import doctor

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from collections.abc import Sequence
 from typing import cast
+
 from typing_extensions import TypeAlias
 
 from devenv import bootstrap

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -18,9 +18,9 @@ help = "Resyncs the environment."
 
 
 def run_procs(
-    repo: str, reporoot: str, _procs: Tuple[Tuple[str, proc.Command], ...]
+    repo: str, reporoot: str, _procs: Tuple[Tuple[str, tuple[str, ...]], ...]
 ) -> bool:
-    procs: list[tuple[str, proc.Command, subprocess.Popen[bytes]]] = []
+    procs: list[tuple[str, tuple[str, ...], subprocess.Popen[bytes]]] = []
 
     for name, cmd in _procs:
         print(f"⏳ {name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 description = "Utilities for setting up a Sentry development environment"
 readme = "README.md"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 description = "Utilities for setting up a Sentry development environment"
 readme = "README.md"
-requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Making devenv compatible with python 3.8 will allow us to use it in Sentry (which still relies on python 3.8).