### PR TITLE
ci: avoid installing the entirety of sentry's brewfile

### DIFF
--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -133,7 +133,16 @@ When done, hit ENTER to continue.
             )
 
         print("Installing sentry's brew dependencies...")
-        proc.run((f"{homebrew_bin}/brew", "bundle"), cwd=f"{coderoot}/sentry")
+        if CI:
+            # Installing everything from brew takes too much time,
+            # and chromedriver cask flakes occasionally. Really all we need to
+            # set up the devenv is colima. This is also required for arm64 macOS GHA runners.
+            # TODO: pin colima in sentry via vendored formula and install from that
+            proc.run(("brew", "install", "colima"))
+        else:
+            proc.run(
+                (f"{homebrew_bin}/brew", "bundle"), cwd=f"{coderoot}/sentry"
+            )
 
         # this'll create the virtualenv if it doesn't exist
         proc.run(("devenv", "sync"), cwd=f"{coderoot}/sentry")


### PR DESCRIPTION
Saves time and chromedriver cask has recently been behaving poorly (in macos arm64 GHA): https://github.com/getsentry/devenv/pull/43#issuecomment-1834624296
