### PR TITLE
fix: proc.run combines stdout and stderr by default

### DIFF
--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -49,7 +49,7 @@ def main(coderoot: str, argv: Sequence[str] | None = None) -> ExitCode:
         # There is a way to perform a headless install but it's more complex
         # (refer to how homebrew does it).
         try:
-            git = proc.run(("xcrun", "-f", "git"), stdout=True)
+            git = proc.run(("xcrun", "-f", "git"))
         except RuntimeError:
             return "Failed to find git. Run xcode-select --install, then re-run bootstrap when done."
         assert Path(git).name == "git"

--- a/devenv/lib/direnv.py
+++ b/devenv/lib/direnv.py
@@ -34,7 +34,7 @@ def install() -> None:
     archive.download(url, _sha256[name], dest=direnv_path)
     os.chmod(direnv_path, 0o775)
 
-    version = proc.run((direnv_path, "version"), stdout=True)
+    version = proc.run((direnv_path, "version"))
     assert version == _version, (version, _version)
 
     fs.idempotent_add(

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -26,9 +26,7 @@ def gitroot(cd: str = "") -> str:
     if not cd:
         cd = os.getcwd()
 
-    stdout = proc.run(
-        ("git", "-C", cd, "rev-parse", "--show-cdup"), exit=True, stdout=True
-    )
+    stdout = proc.run(("git", "-C", cd, "rev-parse", "--show-cdup"), exit=True)
     return normpath(join(cd, stdout))
 
 

--- a/devenv/lib/github.py
+++ b/devenv/lib/github.py
@@ -20,7 +20,7 @@ github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+V
 def check_ssh_authentication() -> bool:
     try:
         # The remote prints to stderr and exits with code 1 in all cases.
-        proc.run(("sh", "-c", "ssh -T git@github.com 2>&1"), stdout=True)
+        proc.run(("sh", "-c", "ssh -T git@github.com 2>&1"))
     except RuntimeError as e:
         # https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection
         if "You've successfully authenticated" not in str(e):

--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -63,7 +63,7 @@ def populate_volta_home_with_shims(unpack_into: str) -> None:
     # executing volta -v will populate the VOLTA_HOME directory
     # with node/npm/yarn shims
     proc.run((f"{unpack_into}/volta-migrate",))
-    version = proc.run((f"{unpack_into}/volta", "-v"), stdout=True)
+    version = proc.run((f"{unpack_into}/volta", "-v"))
     assert version == _version, (version, _version)
 
 

--- a/devenv/lib_check/brew.py
+++ b/devenv/lib_check/brew.py
@@ -17,6 +17,5 @@ def packages() -> list[str]:
             "HOMEBREW_NO_INSTALL_CLEANUP": "1",
             "HOMEBREW_NO_ANALYTICS": "1",
         },
-        stdout=True,
     )
     return stdout.split()

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -123,6 +123,7 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
         )
 
     print("Resyncing your dev environment.")
+    proc.run(("make", "install-py-dev"))
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -123,7 +123,6 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
         )
 
     print("Resyncing your dev environment.")
-    proc.run(("make", "install-py-dev"))
 
     if not run_procs(
         repo,

--- a/tests/volta/test_install.py
+++ b/tests/volta/test_install.py
@@ -43,7 +43,7 @@ def test_install(tmp_path: str) -> None:
             mock_proc_run.assert_has_calls(
                 [
                     call((f"{tmp_path}/bin/volta-migrate",)),
-                    call((f"{tmp_path}/bin/volta", "-v"), stdout=True),
+                    call((f"{tmp_path}/bin/volta", "-v")),
                 ]
             )
             assert mock_idempotent_add.call_args_list == [

--- a/tests/volta/test_populate_volta_home_with_shims.py
+++ b/tests/volta/test_populate_volta_home_with_shims.py
@@ -20,6 +20,6 @@ def test_populate_volta_home_with_shims() -> None:
         mock_run.assert_has_calls(
             [
                 call((f"{unpack_into}/volta-migrate",)),
-                call((f"{unpack_into}/volta", "-v"), stdout=True),
+                call((f"{unpack_into}/volta", "-v")),
             ]
         )


### PR DESCRIPTION
…so that it shows up in sentry if it errors. Someone ran into an issue with `make bootstrap` and the sentry error wasn't useful since stdout+err didn't get put into the exception details: https://sentry.sentry.io/issues/4681931344/events/7ebff3e3a9524b54a949e0bb11b423d2/?project=5723503

I think this is also just a good default and can't remember why I made it an option.