### PR TITLE
ci: regularly test on ubuntu 2204, move macos-13 to main only

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -26,13 +26,6 @@ jobs:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:
       - uses: actions/checkout@v3
-      - name: remove homebrew
-        run: |
-          sudo rm -rf \
-              /usr/local/var/homebrew \
-              /usr/local/bin/brew /usr/local/Homebrew /usr/local/Cellar /usr/local/Caskroom \
-              /usr/local/bin/pydoc* /usr/local/bin/python* /usr/local/bin/2to3* /usr/local/bin/idle3* \
-              /usr/local/bin/chromedriver
       - name: install
         run: |
           set -u
@@ -41,7 +34,6 @@ jobs:
           mv install-devenv.sh /tmp
           cd /tmp
           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-
       - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,6 +19,36 @@ env:
 
 jobs:
   bootstrap:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      SNTY_DEVENV_BRANCH:
+        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
+    steps:
+      - uses: actions/checkout@v3
+      - name: remove homebrew
+        run: |
+          sudo rm -rf \
+              /usr/local/var/homebrew \
+              /usr/local/bin/brew /usr/local/Homebrew /usr/local/Cellar /usr/local/Caskroom \
+              /usr/local/bin/pydoc* /usr/local/bin/python* /usr/local/bin/2to3* /usr/local/bin/idle3* \
+              /usr/local/bin/chromedriver
+      - name: install
+        run: |
+          set -u
+          : should be able to be run from anywhere:
+          repo=$PWD
+          mv install-devenv.sh /tmp
+          cd /tmp
+          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
+
+      - name: bootstrap sentry
+        run: ./ci/devenv-bootstrap.sh
+
+  bootstrap-macos-13:
+    # This job takes half an hour and costs a lot of money.
+    # Let's just run on main commits.
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -12,6 +12,10 @@ name = "getsentry-mock"
 version = "0.0.0"
 EOF
 
+cat ~/.zshrc
+cat ~/.bashrc
+cat ~/.profile
+
 : PATH: "$PATH"
 
 # note: colima will be used and is necessary for a docker runtime on

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -12,10 +12,6 @@ name = "getsentry-mock"
 version = "0.0.0"
 EOF
 
-cat ~/.zshrc
-cat ~/.bashrc
-cat ~/.profile
-
 : PATH: "$PATH"
 
 # note: colima will be used and is necessary for a docker runtime on

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing_extensions import TypeAlias
 
 from devenv.constants import CI
+from devenv.constants import DARWIN
 from devenv.constants import EXTERNAL_CONTRIBUTOR
 from devenv.constants import home
 from devenv.constants import homebrew_bin
@@ -134,11 +135,12 @@ When done, hit ENTER to continue.
 
         print("Installing sentry's brew dependencies...")
         if CI:
-            # Installing everything from brew takes too much time,
-            # and chromedriver cask flakes occasionally. Really all we need to
-            # set up the devenv is colima. This is also required for arm64 macOS GHA runners.
-            # TODO: pin colima in sentry via vendored formula and install from that
-            proc.run(("brew", "install", "colima", "docker"))
+            if DARWIN:
+                # Installing everything from brew takes too much time,
+                # and chromedriver cask flakes occasionally. Really all we need to
+                # set up the devenv is colima. This is also required for arm64 macOS GHA runners.
+                # TODO: pin colima in sentry via vendored formula and install from that
+                proc.run(("brew", "install", "colima", "docker"))
         else:
             proc.run(
                 (f"{homebrew_bin}/brew", "bundle"), cwd=f"{coderoot}/sentry"

--- a/devenv/lib/direnv.py
+++ b/devenv/lib/direnv.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import os
-import platform
 import shutil
+import sys
 
+from devenv.constants import MACHINE
 from devenv.constants import root
 from devenv.constants import shell
 from devenv.lib import archive
@@ -15,6 +16,8 @@ _version = "2.32.3"
 _sha256 = {
     "direnv.darwin-amd64": "6ff42606edb38ffce5e1a3f4a1c69401e42a7c49b8bdc4ddafd705bc770bd15c",
     "direnv.darwin-arm64": "dd053025ecae958118b3db2292721464e68da4fb319b80905a4cebba5ba9f069",
+    "direnv.linux-amd64": "c0443e4600e4b93ec253e663fff18b5fb490cc555b1fc72f0ab22beaa2bb9810",
+    "direnv.linux-arm64": "785684d2b228bcb1e3977545f0215966a5124cdffcf7a01a90cf1bf1aee71483",
 }
 
 
@@ -24,8 +27,8 @@ def install() -> None:
     if shutil.which("direnv") == direnv_path:
         return
 
-    suffix = "arm64" if platform.machine() == "arm64" else "amd64"
-    name = f"direnv.darwin-{suffix}"
+    machine = "arm64" if MACHINE == "arm64" else "amd64"
+    name = f"direnv.{sys.platform}-{machine}"
     url = (
         "https://github.com/direnv/direnv/releases/download"
         f"/v{_version}/{name}"

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -140,9 +140,9 @@ install_python() {
   indygreg_platform="$(indygreg_cpu)-$(indygreg_os)"
 
   case "$indygreg_platform" in
-    aarch64-apple-darwin) sha256=cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4;;
-    x86_64-apple-darwin) sha256=47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00;;
-    x86_64-unknown-linux-gnu) sha256=26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05;;
+    aarch64-apple-darwin)      sha256=cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4;;
+    x86_64-apple-darwin)       sha256=47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00;;
+    x86_64-unknown-linux-gnu)  sha256=e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05;;
     aarch64-unknown-linux-gnu) sha256=2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb;;
     *)
       error "Unexpected platform; please ask in #discuss-dev-infra or contact <team-devenv@sentry.io>: ($platform -> $indygreg_platform)"

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -190,6 +190,7 @@ main() {
     : 'already done!'
   elif yesno 'Use devenv-recommended binaries by default? If you prefer to modify PATH in your own way, say n'; then
     echo "$export" >> ~/.profile
+    echo "$export" >> ~/.bash_profile
     echo "$export" >> ~/.bashrc
     echo "$export" >> ~/.zshrc
     mkdir -p "$XDG_CONFIG_HOME/fish/conf.d"

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -189,6 +189,7 @@ main() {
   if [[ -e ~/.zshrc ]] && grep -qFx "$export" ~/.zshrc; then
     : 'already done!'
   elif yesno 'Use devenv-recommended binaries by default? If you prefer to modify PATH in your own way, say n'; then
+    echo "$export" >> ~/.profile
     echo "$export" >> ~/.bashrc
     echo "$export" >> ~/.zshrc
     mkdir -p "$XDG_CONFIG_HOME/fish/conf.d"


### PR DESCRIPTION
i've grown weary of the 30+ minute macos-13 bootstrap runs and propose to only run them on main

a lot of it is the overhead with installing colima, and while colima is available on macos-12 runners it is not on 13: https://github.com/actions/runner-images/blob/macOS-12/20230825.1/images/macos/macos-13-Readme.md

in its stead i'm adding ubuntu-2204 runs for pull requests (which only takes 5 minutes lmao), which is also good because we want to support devenv on ubuntu

