### PR TITLE
fix: symlink volta bins into devenv bin

### DIFF
--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -72,6 +72,8 @@ def install() -> None:
     if (
         which("volta", path=f"{root}/bin") == f"{root}/bin/volta"
         and which("node", path=f"{VOLTA_HOME}/bin") == f"{VOLTA_HOME}/bin/node"
+        and os.path.exists(f"{root}/bin/node")
+        and os.readlink(f"{root}/bin/node") == f"{VOLTA_HOME}/bin/node"
     ):
         return
 
@@ -80,3 +82,6 @@ def install() -> None:
 
     if not os.path.exists(f"{VOLTA_HOME}/bin/node"):
         raise SystemExit("Failed to install volta!")
+
+    for executable in ("node", "npm", "npx", "yarn", "pnpm"):
+        os.symlink(f"{VOLTA_HOME}/bin/{executable}", f"{root}/bin/{executable}")

--- a/tests/volta/test_install.py
+++ b/tests/volta/test_install.py
@@ -8,28 +8,12 @@ from devenv.lib.volta import _version
 from devenv.lib.volta import install
 
 
-def test_install_already_installed(tmp_path: str) -> None:
-    with patch.multiple(
-        "devenv.lib.volta", root=tmp_path, VOLTA_HOME=f"{tmp_path}/volta"
-    ), patch(
-        "devenv.lib.volta.which",
-        side_effect=[f"{tmp_path}/bin/volta", f"{tmp_path}/volta/bin/node"],
-    ) as mock_which:
-        install()
-        assert mock_which.call_args_list == [
-            call("volta", path=f"{tmp_path}/bin"),
-            call("node", path=f"{tmp_path}/volta/bin"),
-        ]
-
-
 def test_install(tmp_path: str) -> None:
     VOLTA_HOME = f"{tmp_path}/volta"
     os.makedirs(f"{tmp_path}/bin")
     os.makedirs(f"{VOLTA_HOME}/bin")
-
-    def touch_volta_bins() -> None:
-        for executable in ("node", "npm", "npx", "yarn", "pnpm"):
-            open(f"{VOLTA_HOME}/bin/{executable}", "a").close()
+    for executable in ("node", "npm", "npx", "yarn", "pnpm"):
+        open(f"{VOLTA_HOME}/bin/{executable}", "a").close()
 
     with patch.multiple(
         "devenv.lib.volta", root=tmp_path, VOLTA_HOME=VOLTA_HOME
@@ -38,13 +22,8 @@ def test_install(tmp_path: str) -> None:
             "devenv.lib.volta.install_volta"
         ) as mock_install_volta, patch(
             "devenv.lib.volta.proc.run",
-            side_effect=[
-                touch_volta_bins,
-                _version,
-            ],  # volta-migrate  # volta -v
-        ) as mock_proc_run, patch(
-            "devenv.lib.volta.os.path.exists", return_value=True
-        ) as mock_path_exists:
+            side_effect=[None, _version],  # volta-migrate  # volta -v
+        ) as mock_proc_run:
             install()
 
             mock_install_volta.assert_called_once_with(f"{tmp_path}/bin")
@@ -54,10 +33,17 @@ def test_install(tmp_path: str) -> None:
                     call((f"{tmp_path}/bin/volta", "-v"), stdout=True),
                 ]
             )
-            mock_path_exists.assert_called_once_with(
-                f"{tmp_path}/volta/bin/node"
-            )
             assert (
                 os.readlink(f"{tmp_path}/bin/node")
                 == f"{tmp_path}/volta/bin/node"
             )
+
+    # now test already installed
+    with patch.multiple(
+        "devenv.lib.volta", root=tmp_path, VOLTA_HOME=VOLTA_HOME
+    ), patch("devenv.lib.volta.install_volta") as mock_install_volta, patch(
+        "devenv.lib.volta.which",
+        side_effect=[f"{tmp_path}/bin/volta", f"{tmp_path}/volta/bin/node"],
+    ):
+        install()
+        assert not mock_install_volta.called


### PR DESCRIPTION
volta shims aren't on the PATH following https://github.com/getsentry/devenv/pull/51, easiest way to make them available while keeping user's shellrc modifications to a minimum is to put them in devenv's bin which should already be on PATH following an install-devenv.sh