### PR TITLE
feat: manage colima ourselves

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -34,12 +34,6 @@ jobs:
           mv install-devenv.sh /tmp
           cd /tmp
           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-      # qemu required for colima
-      # we explicitly don't support homebrew on linux
-      - name: install qemu
-        uses: docker/setup-qemu-action@v3
-      - name: install qemu-utils
-        run: sudo apt-get update && sudo apt-get install -y qemu-utils
       - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -44,7 +44,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -38,6 +38,8 @@ jobs:
       # we explicitly don't support homebrew on linux
       - name: install qemu
         uses: docker/setup-qemu-action@v3
+      - name: install qemu-utils
+        run: sudo apt-get update && sudo apt-get install -y qemu-utils
       - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -44,7 +44,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -34,6 +34,10 @@ jobs:
           mv install-devenv.sh /tmp
           cd /tmp
           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
+      # qemu required for colima
+      # we explicitly don't support homebrew on linux
+      - name: install qemu
+        uses: docker/setup-qemu-action@v3
       - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh
 

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -157,13 +157,6 @@ When done, hit ENTER to continue.
         #       i'll follow-up with fixing that in sentry
         shutil.rmtree(f"{home}/.sentry")
 
-        proc.run(
-            ("python", "-c", "import shutil; print(shutil.which('colima'))"),
-            env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
-            pathprepend=f"{coderoot}/sentry/.venv/bin",
-            cwd=f"{coderoot}/sentry",
-        )
-
         # make bootstrap should be ported over to devenv sync,
         # as it applies new migrations as well and so would need to ensure
         # the appropriate devservices are running

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -105,14 +105,7 @@ When done, hit ENTER to continue.
             # git@ clones forces the use of cloning through SSH which is what we want,
             # though CI must clone open source repos via https (no git authentication)
             additional_flags = (
-                (
-                    "--depth",
-                    "1",
-                    "--single-branch",
-                    "--branch",
-                    "start-colima-linux",
-                    "https://github.com/getsentry/sentry",
-                )
+                ("--depth", "1", "https://github.com/getsentry/sentry")
                 if CI
                 else ("git@github.com:getsentry/sentry",)
             )

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -157,6 +157,13 @@ When done, hit ENTER to continue.
         #       i'll follow-up with fixing that in sentry
         shutil.rmtree(f"{home}/.sentry")
 
+        proc.run(
+            ("python", "-c", "import shutil; print(shutil.which('colima'))"),
+            env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
+            pathprepend=f"{coderoot}/sentry/.venv/bin",
+            cwd=f"{coderoot}/sentry",
+        )
+
         # make bootstrap should be ported over to devenv sync,
         # as it applies new migrations as well and so would need to ensure
         # the appropriate devservices are running

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -92,9 +92,11 @@ When done, hit ENTER to continue.
 
     brew.install()
     volta.install()
-    colima.install()
-    limactl.install()
     direnv.install()
+
+    if DARWIN:
+        colima.install()
+        limactl.install()
 
     os.makedirs(coderoot, exist_ok=True)
 

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -15,6 +15,7 @@ from devenv.constants import home
 from devenv.constants import homebrew_bin
 from devenv.constants import VOLTA_HOME
 from devenv.lib import brew
+from devenv.lib import colima
 from devenv.lib import direnv
 from devenv.lib import github
 from devenv.lib import proc
@@ -90,6 +91,7 @@ When done, hit ENTER to continue.
 
     brew.install()
     volta.install()
+    colima.install()
     direnv.install()
 
     os.makedirs(coderoot, exist_ok=True)
@@ -138,9 +140,10 @@ When done, hit ENTER to continue.
             if DARWIN:
                 # Installing everything from brew takes too much time,
                 # and chromedriver cask flakes occasionally. Really all we need to
-                # set up the devenv is colima. This is also required for arm64 macOS GHA runners.
-                # TODO: pin colima in sentry via vendored formula and install from that
-                proc.run(("brew", "install", "colima", "docker"))
+                # set up the devenv is colima and docker-cli.
+                # This is also required for arm64 macOS GHA runners.
+                # We manage colima, so just need to install docker here.
+                proc.run(("brew", "install", "docker"))
         else:
             proc.run(
                 (f"{homebrew_bin}/brew", "bundle"), cwd=f"{coderoot}/sentry"

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -101,7 +101,7 @@ When done, hit ENTER to continue.
             # git@ clones forces the use of cloning through SSH which is what we want,
             # though CI must clone open source repos via https (no git authentication)
             additional_flags = (
-                ("--depth", "1", "https://github.com/getsentry/sentry")
+                ("--depth", "1", "--single-branch", "--branch", "start-colima-linux", "https://github.com/getsentry/sentry")
                 if CI
                 else ("git@github.com:getsentry/sentry",)
             )

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -146,6 +146,7 @@ When done, hit ENTER to continue.
 
         print("Installing sentry's brew dependencies...")
         if CI:
+            proc.run(("brew", "install", "qemu"))
             if DARWIN:
                 # Installing everything from brew takes too much time,
                 # and chromedriver cask flakes occasionally. Really all we need to

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -146,14 +146,13 @@ When done, hit ENTER to continue.
 
         print("Installing sentry's brew dependencies...")
         if CI:
-            proc.run(("brew", "install", "qemu"))
             if DARWIN:
                 # Installing everything from brew takes too much time,
                 # and chromedriver cask flakes occasionally. Really all we need to
                 # set up the devenv is colima and docker-cli.
                 # This is also required for arm64 macOS GHA runners.
-                # We manage colima, so just need to install docker here.
-                proc.run(("brew", "install", "docker"))
+                # We manage colima, so just need to install docker + qemu here.
+                proc.run(("brew", "install", "docker", "qemu"))
         else:
             proc.run(
                 (f"{homebrew_bin}/brew", "bundle"), cwd=f"{coderoot}/sentry"

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -18,6 +18,7 @@ from devenv.lib import brew
 from devenv.lib import colima
 from devenv.lib import direnv
 from devenv.lib import github
+from devenv.lib import limactl
 from devenv.lib import proc
 from devenv.lib import volta
 
@@ -92,6 +93,7 @@ When done, hit ENTER to continue.
     brew.install()
     volta.install()
     colima.install()
+    limactl.install()
     direnv.install()
 
     os.makedirs(coderoot, exist_ok=True)
@@ -101,7 +103,14 @@ When done, hit ENTER to continue.
             # git@ clones forces the use of cloning through SSH which is what we want,
             # though CI must clone open source repos via https (no git authentication)
             additional_flags = (
-                ("--depth", "1", "--single-branch", "--branch", "start-colima-linux", "https://github.com/getsentry/sentry")
+                (
+                    "--depth",
+                    "1",
+                    "--single-branch",
+                    "--branch",
+                    "start-colima-linux",
+                    "https://github.com/getsentry/sentry",
+                )
                 if CI
                 else ("git@github.com:getsentry/sentry",)
             )

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -26,6 +26,7 @@ user_environ: typing.Mapping[str, str] = os.environ.copy()
 cache_root = f"{home}/.cache/sentry-devenv"
 config_root = f"{home}/.config/sentry-devenv"
 root = f"{home}/.local/share/sentry-devenv"
+bin_root = f"{root}/bin"
 src_root = f"{root}/devenv"
 pythons_root = f"{root}/pythons"
 

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -30,14 +30,15 @@ bin_root = f"{root}/bin"
 src_root = f"{root}/devenv"
 pythons_root = f"{root}/pythons"
 
-
-if INTEL_MAC:
-    homebrew_repo = "/usr/local/Homebrew"
-    homebrew_bin = "/usr/local/bin"
-else:  # FIXME: elif ARM_MAC
-    homebrew_repo = "/opt/homebrew"
+if DARWIN:
+    if MACHINE == "x86_64":
+        homebrew_repo = "/usr/local/Homebrew"
+        homebrew_bin = "/usr/local/bin"
+    else:
+        homebrew_repo = "/opt/homebrew"
+        homebrew_bin = f"{homebrew_repo}/bin"
+else:
+    homebrew_repo = f"{home}/linuxbrew/.linuxbrew"
     homebrew_bin = f"{homebrew_repo}/bin"
-# FIXME: elif linux: "/home/linuxbrew/.linuxbrew
-# TODO: instead, symlink to /opt/homebrew in all cases, for consistency
 
 VOLTA_HOME = f"{root}/volta"

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -30,14 +30,10 @@ bin_root = f"{root}/bin"
 src_root = f"{root}/devenv"
 pythons_root = f"{root}/pythons"
 
-
+homebrew_repo = "/opt/homebrew"
+homebrew_bin = f"{homebrew_repo}/bin"
 if INTEL_MAC:
     homebrew_repo = "/usr/local/Homebrew"
     homebrew_bin = "/usr/local/bin"
-else:  # FIXME: elif ARM_MAC
-    homebrew_repo = "/opt/homebrew"
-    homebrew_bin = f"{homebrew_repo}/bin"
-# FIXME: elif linux: "/home/linuxbrew/.linuxbrew
-# TODO: instead, symlink to /opt/homebrew in all cases, for consistency
 
 VOLTA_HOME = f"{root}/volta"

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -30,15 +30,14 @@ bin_root = f"{root}/bin"
 src_root = f"{root}/devenv"
 pythons_root = f"{root}/pythons"
 
-if DARWIN:
-    if MACHINE == "x86_64":
-        homebrew_repo = "/usr/local/Homebrew"
-        homebrew_bin = "/usr/local/bin"
-    else:
-        homebrew_repo = "/opt/homebrew"
-        homebrew_bin = f"{homebrew_repo}/bin"
-else:
-    homebrew_repo = f"{home}/linuxbrew/.linuxbrew"
+
+if INTEL_MAC:
+    homebrew_repo = "/usr/local/Homebrew"
+    homebrew_bin = "/usr/local/bin"
+else:  # FIXME: elif ARM_MAC
+    homebrew_repo = "/opt/homebrew"
     homebrew_bin = f"{homebrew_repo}/bin"
+# FIXME: elif linux: "/home/linuxbrew/.linuxbrew
+# TODO: instead, symlink to /opt/homebrew in all cases, for consistency
 
 VOLTA_HOME = f"{root}/volta"

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -23,7 +23,10 @@ def download(url: str, sha256: str, dest: str = "") -> str:
         except HTTPError as e:
             raise RuntimeError(f"Error getting {url}: {e}")
 
-        with tempfile.NamedTemporaryFile(delete=False) as tmpf:
+        with tempfile.NamedTemporaryFile(
+            delete=False,
+            dir=os.path.dirname(dest),  # needed to guarantee an atomic rename
+        ) as tmpf:
             shutil.copyfileobj(resp, tmpf)
             tmpf.seek(0)
             checksum = hashlib.sha256()

--- a/devenv/lib/brew.py
+++ b/devenv/lib/brew.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from shutil import which
 
+from devenv.constants import DARWIN
 from devenv.constants import homebrew_bin
 from devenv.constants import homebrew_repo
 from devenv.constants import INTEL_MAC
@@ -45,6 +46,9 @@ eval "$({homebrew_bin}/brew shellenv)"
 
 
 def install() -> None:
+    if not DARWIN:
+        return
+
     # idempotency: skip if brew is on the executing shell's path
     if which("brew") is not None:
         return

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import platform
+from shutil import which
+
+from devenv.constants import bin_root
+from devenv.constants import MACHINE
+from devenv.lib import archive
+
+_version = "0.6.2"
+_sha256 = {
+    "colima-Darwin-arm64": "add68719cc2a8e29be331177534db19812f9f79621425878cd88f890ca0db476",
+    "colima-Darwin-x86_64": "43ef3fc80a8347d51b8ec1706f9caf8863bd8727a6f7532caf1ccd20497d8485",
+    "colima-Linux-aarch64": "a04dbdfff0d913502b948ed1025d0d12485780493de24750b867c06a6325b5d5",
+    "colima-Linux-x86_64": "58e1a13fb0f693a6b28c2d935856e3f4bab6f0ab93f6bf4c860b5d59791ed04f",
+}
+
+
+class UnexpectedPlatformError(Exception):
+    pass
+
+
+def build_name() -> str | None:
+    system = platform.system()
+    if system == "Linux":
+        if MACHINE == "arm64":
+            return "colima-Linux-aarch64"
+        return f"colima-Linux-{MACHINE}"
+    elif system == "Darwin":
+        return f"colima-Darwin-{MACHINE}"
+    else:
+        raise UnexpectedPlatformError(f"Unexpected OS: {platform.platform()}")
+
+
+def download(name: str, into: str) -> None:
+    url = (
+        "https://github.com/abiosoft/colima/releases/download/"
+        f"v{_version}/{name}"
+    )
+
+    archive.download(url, _sha256[name], dest=f"{into}/colima")
+    os.chmod(f"{into}/colima", 0o775)
+
+
+def _install(into: str) -> None:
+    name = build_name()
+    if name is None:
+        return
+    download(name, into)
+
+
+def install() -> None:
+    if which("colima", path=bin_root) == f"{bin_root}/colima":
+        return
+
+    _install(bin_root)
+
+    if not os.path.exists(f"{bin_root}/colima"):
+        raise SystemExit("Failed to install colima!")

--- a/devenv/lib/limactl.py
+++ b/devenv/lib/limactl.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import platform
+import tempfile
+from shutil import which
+
+from devenv.constants import bin_root
+from devenv.constants import MACHINE
+from devenv.lib import archive
+
+_version = "0.19.1"
+_sha256 = {
+    f"lima-{_version}-Darwin-arm64.tar.gz": "0dfcf3a39782baf1c2ea43cf026f8df0321c671d914c105fbb78de507aa8bda4",
+    f"lima-{_version}-Darwin-x86_64.tar.gz": "ac8827479f66ef1b288b31f164b22f6433faa14c44ce5bbebe09e6e913582479",
+    f"lima-{_version}-Linux-aarch64.tar.gz": "c55e57ddbefd9988d0f3676bb873bcc6e0f7b3c3d47a1f07599ee151c5198d96",
+    f"lima-{_version}-Linux-x86_64.tar.gz": "7d18b1716aae14bf98d6ea93a703e8877b0c3142f7ba2e87401d47d5d0fe3ff1",
+}
+
+
+class UnexpectedPlatformError(Exception):
+    pass
+
+
+def build_name() -> str | None:
+    system = platform.system()
+    if system == "Linux":
+        if MACHINE == "arm64":
+            return f"lima-{_version}-{system}-aarch64.tar.gz"
+        return f"lima-{_version}-{system}-{MACHINE}.tar.gz"
+    elif system == "Darwin":
+        return f"lima-{_version}-{system}-{MACHINE}.tar.gz"
+    else:
+        raise UnexpectedPlatformError(f"Unexpected OS: {platform.platform()}")
+
+
+def download_and_unpack_archive(name: str, into: str) -> None:
+    url = (
+        "https://github.com/lima-vm/lima/releases/download/"
+        f"v{_version}/{name}"
+    )
+
+    archive_file = archive.download(url, _sha256[name], dest=f"{into}/{name}")
+    archive.unpack(archive_file, into)
+
+
+def _install(into: str) -> None:
+    name = build_name()
+    if name is None:
+        return
+
+    with tempfile.TemporaryDirectory(dir=into) as tmpd:
+        download_and_unpack_archive(name, tmpd)
+
+        # the archive was atomically placed into tmpd so
+        # these are on the same fs and can be atomically moved too
+        os.replace(f"{tmpd}/bin/lima", f"{into}/lima")
+        os.replace(f"{tmpd}/bin/limactl", f"{into}/limactl")
+        os.replace(
+            f"{tmpd}/share/lima/lima-guestagent.Linux-aarch64",
+            f"{into}/lima-guestagent.Linux-aarch64",
+        )
+        os.replace(
+            f"{tmpd}/share/lima/lima-guestagent.Linux-x86_64",
+            f"{into}/lima-guestagent.Linux-x86_64",
+        )
+        os.makedirs(f"{into}/templates", exist_ok=True)
+        os.replace(
+            f"{tmpd}/share/lima/templates/default.yaml",
+            f"{into}/templates/default.yaml",
+        )
+
+
+def install() -> None:
+    # this needs to be better
+    if (
+        which("lima", path=bin_root) == f"{bin_root}/lima"
+        and which("limactl", path=bin_root) == f"{bin_root}/limactl"
+    ):
+        return
+
+    _install(bin_root)
+
+    if not os.path.exists(f"{bin_root}/lima") or not os.path.exists(
+        f"{bin_root}/limactl"
+    ):
+        raise SystemExit("Failed to install colima!")

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -124,6 +124,13 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
             exit=True,
         )
 
+    proc.run(
+        ("python", "-c", "import shutil; print(shutil.which('colima'))"),
+        env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
+        pathprepend=f"{reporoot}/.venv/bin",
+        cwd=reporoot,
+    )
+
     print("Resyncing your dev environment.")
 
     if not run_procs(

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -12,8 +12,6 @@ from typing import Tuple
 
 from devenv import constants
 from devenv import pythons
-from devenv.constants import CI
-from devenv.constants import DARWIN
 from devenv.constants import home
 from devenv.constants import MACHINE
 from devenv.constants import VOLTA_HOME
@@ -152,16 +150,6 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
     volta.install()
     colima.install()
     limactl.install()
-
-    if CI and not DARWIN:
-        # let's test colima on linux CI as well!
-        # this can be moved to devservices in the future (use colima if docker isn't available)
-        proc.run(
-            ("python3", "-uS", "scripts/start-colima.py"),
-            env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
-            pathprepend=f"{reporoot}/.venv/bin",
-            cwd=reporoot,
-        )
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -15,6 +15,7 @@ from devenv import pythons
 from devenv.constants import home
 from devenv.constants import MACHINE
 from devenv.constants import VOLTA_HOME
+from devenv.lib import colima
 from devenv.lib import proc
 from devenv.lib import volta
 
@@ -146,6 +147,7 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
     # make install-js-dev will fail since our run_procs expects devenv-managed
     # volta.
     volta.install()
+    colima.install()
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -18,6 +18,7 @@ from devenv.constants import home
 from devenv.constants import MACHINE
 from devenv.constants import VOLTA_HOME
 from devenv.lib import colima
+from devenv.lib import limactl
 from devenv.lib import proc
 from devenv.lib import volta
 
@@ -126,16 +127,6 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
             exit=True,
         )
 
-    if CI and not DARWIN:
-        # let's test colima on linux CI as well!
-        # this can be moved to devservices in the future (use colima if docker isn't available)
-        proc.run(
-            ("python3", "-uS", "scripts/start-colima.py"),
-            env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
-            pathprepend=f"{reporoot}/.venv/bin",
-            cwd=reporoot,
-        )
-
     print("Resyncing your dev environment.")
 
     if not run_procs(
@@ -160,6 +151,17 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
     # volta.
     volta.install()
     colima.install()
+    limactl.install()
+
+    if CI and not DARWIN:
+        # let's test colima on linux CI as well!
+        # this can be moved to devservices in the future (use colima if docker isn't available)
+        proc.run(
+            ("python3", "-uS", "scripts/start-colima.py"),
+            env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
+            pathprepend=f"{reporoot}/.venv/bin",
+            cwd=reporoot,
+        )
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -12,6 +12,8 @@ from typing import Tuple
 
 from devenv import constants
 from devenv import pythons
+from devenv.constants import CI
+from devenv.constants import DARWIN
 from devenv.constants import home
 from devenv.constants import MACHINE
 from devenv.constants import VOLTA_HOME
@@ -124,12 +126,15 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
             exit=True,
         )
 
-    proc.run(
-        ("python", "-c", "import shutil; print(shutil.which('colima'))"),
-        env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
-        pathprepend=f"{reporoot}/.venv/bin",
-        cwd=reporoot,
-    )
+    if CI and not DARWIN:
+        # let's test colima on linux CI as well!
+        # this can be moved to devservices in the future (use colima if docker isn't available)
+        proc.run(
+            ("python3", "-uS", "scripts/start-colima.py"),
+            env={"VIRTUAL_ENV": f"{reporoot}/.venv"},
+            pathprepend=f"{reporoot}/.venv/bin",
+            cwd=reporoot,
+        )
 
     print("Resyncing your dev environment.")
 

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -12,6 +12,7 @@ from typing import Tuple
 
 from devenv import constants
 from devenv import pythons
+from devenv.constants import DARWIN
 from devenv.constants import home
 from devenv.constants import MACHINE
 from devenv.constants import VOLTA_HOME
@@ -148,8 +149,11 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
     # make install-js-dev will fail since our run_procs expects devenv-managed
     # volta.
     volta.install()
-    colima.install()
-    limactl.install()
+
+    if DARWIN:
+        # we don't support colima on linux
+        colima.install()
+        limactl.install()
 
     if not run_procs(
         repo,

--- a/tests/brew/test_install.py
+++ b/tests/brew/test_install.py
@@ -34,7 +34,7 @@ def test_install_brew_not_installed_intel_mac() -> None:
     ) as mock_add_brew_to_shellrc, patch(
         "devenv.lib.brew.INTEL_MAC", True
     ), patch(
-        "devenv.constants.DARWIN", True
+        "devenv.lib.brew.DARWIN", True
     ), patch(
         "devenv.lib.brew.proc.run"
     ) as mock_run, patch(
@@ -75,7 +75,7 @@ def test_install_brew_not_installed_non_intel_mac() -> None:
     ) as mock_add_brew_to_shellrc, patch(
         "devenv.lib.brew.INTEL_MAC", False
     ), patch(
-        "devenv.constants.DARWIN", True
+        "devenv.lib.brew.DARWIN", True
     ), patch(
         "devenv.lib.brew.proc.run"
     ) as mock_run, patch(

--- a/tests/brew/test_install.py
+++ b/tests/brew/test_install.py
@@ -34,6 +34,8 @@ def test_install_brew_not_installed_intel_mac() -> None:
     ) as mock_add_brew_to_shellrc, patch(
         "devenv.lib.brew.INTEL_MAC", True
     ), patch(
+        "devenv.constants.DARWIN", True
+    ), patch(
         "devenv.lib.brew.proc.run"
     ) as mock_run, patch(
         "os.symlink"
@@ -72,6 +74,8 @@ def test_install_brew_not_installed_non_intel_mac() -> None:
         "devenv.lib.brew.add_brew_to_shellrc"
     ) as mock_add_brew_to_shellrc, patch(
         "devenv.lib.brew.INTEL_MAC", False
+    ), patch(
+        "devenv.constants.DARWIN", True
     ), patch(
         "devenv.lib.brew.proc.run"
     ) as mock_run, patch(


### PR DESCRIPTION
some people have been running into issues with bad colima versions, with 0.6.2 being the known good one 

i haven't found a way to add/reference a local formula file to Brewfile, and i'm thinking the best path forward is to just let devenv install colima which is just a go binary which just works per my testing

really don't like how brew doesn't let you easily install a particular version of something and i don't want people to get broken by updating colima
