### PR TITLE
ref: replace assert_has_calls with comparing against ordered mock_calls

### DIFF
--- a/tests/lib/test_volta.py
+++ b/tests/lib/test_volta.py
@@ -33,12 +33,10 @@ def test_install(tmp_path: str) -> None:
             install()
 
             mock_install_volta.assert_called_once_with(f"{tmp_path}/bin")
-            mock_proc_run.assert_has_calls(
-                [
-                    call((f"{tmp_path}/bin/volta-migrate",)),
-                    call((f"{tmp_path}/bin/volta", "-v"), stdout=True),
-                ]
-            )
+            assert mock_proc_run.mock_calls == [
+                call((f"{tmp_path}/bin/volta-migrate",)),
+                call((f"{tmp_path}/bin/volta", "-v"), stdout=True),
+            ]
             assert (
                 os.readlink(f"{tmp_path}/bin/node")
                 == f"{tmp_path}/volta/bin/node"
@@ -140,9 +138,7 @@ def test_populate_volta_home_with_shims() -> None:
 
         populate_volta_home_with_shims(unpack_into)
 
-        mock_run.assert_has_calls(
-            [
-                call((f"{unpack_into}/volta-migrate",)),
-                call((f"{unpack_into}/volta", "-v"), stdout=True),
-            ]
-        )
+        assert mock_run.mock_calls == [
+            call((f"{unpack_into}/volta-migrate",)),
+            call((f"{unpack_into}/volta", "-v"), stdout=True),
+        ]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -45,31 +45,29 @@ def test_darwin(tmp_path: str) -> None:
         mock_direnv_install.assert_called_once()
         mock_colima_install.assert_called_once()
         mock_limactl_install.assert_called_once()
-        mock_proc_run.assert_has_calls(
-            [
-                call(
-                    (
-                        "git",
-                        "-C",
-                        coderoot,
-                        "clone",
-                        "--filter=blob:none",
-                        "--depth",
-                        "1",
-                        "https://github.com/getsentry/sentry",
-                    ),
-                    exit=True,
+        assert mock_proc_run.mock_calls == [
+            call(
+                (
+                    "git",
+                    "-C",
+                    coderoot,
+                    "clone",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "https://github.com/getsentry/sentry",
                 ),
-                call(("brew", "install", "docker", "qemu")),
-                call(("devenv", "sync"), cwd=f"{coderoot}/sentry"),
-                call(
-                    ("make", "bootstrap"),
-                    env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
-                    pathprepend=f"{coderoot}/sentry/.venv/bin",
-                    cwd=f"{coderoot}/sentry",
-                ),
-            ]
-        )
+                exit=True,
+            ),
+            call(("brew", "install", "docker", "qemu")),
+            call(("devenv", "sync"), cwd=f"{coderoot}/sentry"),
+            call(
+                ("make", "bootstrap"),
+                env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
+                pathprepend=f"{coderoot}/sentry/.venv/bin",
+                cwd=f"{coderoot}/sentry",
+            ),
+        ]
 
 
 def test_linux(tmp_path: str) -> None:
@@ -110,27 +108,25 @@ def test_linux(tmp_path: str) -> None:
         mock_direnv_install.assert_called_once()
         mock_colima_install.assert_not_called()
         mock_limactl_install.assert_not_called()
-        mock_proc_run.assert_has_calls(
-            [
-                call(
-                    (
-                        "git",
-                        "-C",
-                        coderoot,
-                        "clone",
-                        "--filter=blob:none",
-                        "--depth",
-                        "1",
-                        "https://github.com/getsentry/sentry",
-                    ),
-                    exit=True,
+        assert mock_proc_run.mock_calls == [
+            call(
+                (
+                    "git",
+                    "-C",
+                    coderoot,
+                    "clone",
+                    "--filter=blob:none",
+                    "--depth",
+                    "1",
+                    "https://github.com/getsentry/sentry",
                 ),
-                call(("devenv", "sync"), cwd=f"{coderoot}/sentry"),
-                call(
-                    ("make", "bootstrap"),
-                    env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
-                    pathprepend=f"{coderoot}/sentry/.venv/bin",
-                    cwd=f"{coderoot}/sentry",
-                ),
-            ]
-        )
+                exit=True,
+            ),
+            call(("devenv", "sync"), cwd=f"{coderoot}/sentry"),
+            call(
+                ("make", "bootstrap"),
+                env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
+                pathprepend=f"{coderoot}/sentry/.venv/bin",
+                cwd=f"{coderoot}/sentry",
+            ),
+        ]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -52,60 +52,56 @@ def test_darwin(tmp_path: str) -> None:
         mock_volta_install.assert_called_once()
         mock_colima_install.assert_called_once()
         mock_limactl_install.assert_called_once()
-        mock_proc_run.assert_has_calls(
-            [
-                call(
-                    (
-                        f"{pythons_root}/{python_version}/python/bin/python3",
-                        "-m",
-                        "venv",
-                        venv,
-                    ),
-                    exit=True,
-                ),
-                call((f"{venv}/bin/sentry", "init", "--dev")),
-                call(
-                    (
-                        f"{venv}/bin/sentry",
-                        "devservices",
-                        "up",
-                        "redis",
-                        "postgres",
-                    ),
-                    exit=True,
-                ),
-            ]
-        )
-        mock_run_procs.assert_has_calls(
-            [
-                call(
-                    "sentry",
-                    reporoot,
+        assert mock_proc_run.mock_calls == [
+            call(
+                (
+                    f"{pythons_root}/{python_version}/python/bin/python3",
+                    "-m",
+                    "venv",
                     venv,
-                    (("git and precommit", ("make", "setup-git")),),
                 ),
-                call(
-                    "sentry",
-                    reporoot,
-                    venv,
+                exit=True,
+            ),
+            call((f"{venv}/bin/sentry", "init", "--dev")),
+            call(
+                (
+                    f"{venv}/bin/sentry",
+                    "devservices",
+                    "up",
+                    "redis",
+                    "postgres",
+                ),
+                exit=True,
+            ),
+        ]
+        assert mock_run_procs.mock_calls == [
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (("git and precommit", ("make", "setup-git")),),
+            ),
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (
+                    ("javascript dependencies", ("make", "install-js-dev")),
+                    ("python dependencies", ("make", "install-py-dev")),
+                ),
+            ),
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (
                     (
-                        ("javascript dependencies", ("make", "install-js-dev")),
-                        ("python dependencies", ("make", "install-py-dev")),
+                        "python migrations",
+                        (f"{venv}/bin/sentry", "upgrade", "--noinput"),
                     ),
                 ),
-                call(
-                    "sentry",
-                    reporoot,
-                    venv,
-                    (
-                        (
-                            "python migrations",
-                            (f"{venv}/bin/sentry", "upgrade", "--noinput"),
-                        ),
-                    ),
-                ),
-            ]
-        )
+            ),
+        ]
 
 
 def test_linux(tmp_path: str) -> None:
@@ -138,57 +134,53 @@ def test_linux(tmp_path: str) -> None:
         mock_volta_install.assert_called_once()
         mock_colima_install.assert_not_called()
         mock_limactl_install.assert_not_called()
-        mock_proc_run.assert_has_calls(
-            [
-                call(
-                    (
-                        f"{pythons_root}/{python_version}/python/bin/python3",
-                        "-m",
-                        "venv",
-                        venv,
-                    ),
-                    exit=True,
-                ),
-                call((f"{venv}/bin/sentry", "init", "--dev")),
-                call(
-                    (
-                        f"{venv}/bin/sentry",
-                        "devservices",
-                        "up",
-                        "redis",
-                        "postgres",
-                    ),
-                    exit=True,
-                ),
-            ]
-        )
-        mock_run_procs.assert_has_calls(
-            [
-                call(
-                    "sentry",
-                    reporoot,
+        assert mock_proc_run.mock_calls == [
+            call(
+                (
+                    f"{pythons_root}/{python_version}/python/bin/python3",
+                    "-m",
+                    "venv",
                     venv,
-                    (("git and precommit", ("make", "setup-git")),),
                 ),
-                call(
-                    "sentry",
-                    reporoot,
-                    venv,
+                exit=True,
+            ),
+            call((f"{venv}/bin/sentry", "init", "--dev")),
+            call(
+                (
+                    f"{venv}/bin/sentry",
+                    "devservices",
+                    "up",
+                    "redis",
+                    "postgres",
+                ),
+                exit=True,
+            ),
+        ]
+        assert mock_run_procs.mock_calls == [
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (("git and precommit", ("make", "setup-git")),),
+            ),
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (
+                    ("javascript dependencies", ("make", "install-js-dev")),
+                    ("python dependencies", ("make", "install-py-dev")),
+                ),
+            ),
+            call(
+                "sentry",
+                reporoot,
+                venv,
+                (
                     (
-                        ("javascript dependencies", ("make", "install-js-dev")),
-                        ("python dependencies", ("make", "install-py-dev")),
+                        "python migrations",
+                        (f"{venv}/bin/sentry", "upgrade", "--noinput"),
                     ),
                 ),
-                call(
-                    "sentry",
-                    reporoot,
-                    venv,
-                    (
-                        (
-                            "python migrations",
-                            (f"{venv}/bin/sentry", "upgrade", "--noinput"),
-                        ),
-                    ),
-                ),
-            ]
-        )
+            ),
+        ]


### PR DESCRIPTION
this finishes replacing assert_has_calls (which can be true on subsets of calls) to strictly comparing against all calls done in-order 