### PR TITLE
feat: multiple configurable venvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 __pycache__/
 venv/
+build/
 
 # dirty hacks
 trash/

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -29,6 +29,11 @@ root = f"{home}/.local/share/sentry-devenv"
 bin_root = f"{root}/bin"
 src_root = f"{root}/devenv"
 pythons_root = f"{root}/pythons"
+venvs_root = f"{root}/venvs"
+
+# TODO: makedirs everything but change to a dict
+# root = {"cache": "...", ...}
+os.makedirs(venvs_root, exist_ok=True)
 
 homebrew_repo = "/opt/homebrew"
 homebrew_bin = f"{homebrew_repo}/bin"

--- a/devenv/lib/config.py
+++ b/devenv/lib/config.py
@@ -2,10 +2,25 @@ from __future__ import annotations
 
 import configparser
 import functools
+import sys
+
+from devenv.constants import MACHINE
 
 
 @functools.lru_cache(maxsize=None)
-def repo_config(reporoot: str) -> configparser.ConfigParser:
+def get_repo(reporoot: str) -> configparser.ConfigParser:
     config = configparser.ConfigParser()
     config.read(f"{reporoot}/devenv/config.ini")
     return config
+
+
+def get_python(reporoot: str, python_version: str) -> tuple[str, str]:
+    cfg = get_repo(reporoot)
+
+    # TODO: need to support multiple python versions
+    #       because we support multiple virtualenvs
+    #       which shouldn't be constrained to the same
+    #       python version
+    url = cfg["python"][f"{sys.platform}_{MACHINE}"]
+    sha256 = cfg["python"][f"{sys.platform}_{MACHINE}_sha256"]
+    return url, sha256

--- a/devenv/lib/config.py
+++ b/devenv/lib/config.py
@@ -16,11 +16,14 @@ def get_repo(reporoot: str) -> configparser.ConfigParser:
 
 def get_python(reporoot: str, python_version: str) -> tuple[str, str]:
     cfg = get_repo(reporoot)
+    url = cfg[f"python{python_version}"][f"{sys.platform}_{MACHINE}"]
+    sha256 = cfg[f"python{python_version}"][f"{sys.platform}_{MACHINE}_sha256"]
+    return url, sha256
 
-    # TODO: need to support multiple python versions
-    #       because we support multiple virtualenvs
-    #       which shouldn't be constrained to the same
-    #       python version
+
+# only used for sentry/getsentry
+def get_python_legacy(reporoot: str, python_version: str) -> tuple[str, str]:
+    cfg = get_repo(reporoot)
     url = cfg["python"][f"{sys.platform}_{MACHINE}"]
     sha256 = cfg["python"][f"{sys.platform}_{MACHINE}_sha256"]
     return url, sha256

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -49,13 +49,14 @@ def write_script(filepath: str, text: str) -> None:
 def ensure_symlink(expected_src: str, dest: str) -> None:
     try:
         src = os.readlink(dest)
+        if src != expected_src:
+            print(f"WARNING: {dest} unexpectedly points to {src}")
+            return
     except FileNotFoundError:
         pass
     except OSError as e:
         if e.errno == 22:
             print(f"WARNING: {dest} exists and isn't a symlink")
             return
-    if src != expected_src:
-        print(f"WARNING: {dest} unexpectedly points to {src}")
-        return
+
     os.symlink(expected_src, dest)

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -53,10 +53,8 @@ def ensure_symlink(expected_src: str, dest: str) -> None:
             print(f"WARNING: {dest} unexpectedly points to {src}")
             return
     except FileNotFoundError:
-        pass
+        os.symlink(expected_src, dest)
     except OSError as e:
         if e.errno == 22:
             print(f"WARNING: {dest} exists and isn't a symlink")
             return
-
-    os.symlink(expected_src, dest)

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -44,3 +44,18 @@ def write_script(filepath: str, text: str) -> None:
     with open(filepath, "w") as f:
         f.write(text)
     os.chmod(filepath, 0o775)
+
+
+def ensure_symlink(expected_src: str, dest: str) -> None:
+    try:
+        src = os.readlink(dest)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        if e.errno == 22:
+            print(f"WARNING: {dest} exists and isn't a symlink")
+            return
+    if src != expected_src:
+        print(f"WARNING: {dest} unexpectedly points to {src}")
+        return
+    os.symlink(expected_src, dest)

--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -5,8 +5,10 @@ import shutil
 from typing import Optional
 
 from devenv import pythons
+from devenv.constants import bin_root
 from devenv.constants import venvs_root
 from devenv.lib import config
+from devenv.lib import fs
 from devenv.lib import proc
 
 VENV_OK = 1
@@ -15,7 +17,7 @@ VENV_NOT_PRESENT = 3
 VENV_NOT_CONFIGURED = 4
 
 
-# example venv configuration section.
+# example venv configuration section:
 #
 # [venv.sentry-kube]
 # python = 3.11.6
@@ -24,17 +26,26 @@ VENV_NOT_CONFIGURED = 4
 # editable =
 #   k8s/cli
 #   k8s/cli/libsentrykube
+# bins =
+#   sentry-kube
+#   sentry-kube-pop
 #
 # [venv.salt]
 # python = 3.11.6
-# ...
+# requirements = salt/requirements.txt
+# bins =
+#   salt-ssh
+#   ...
 #
-# venv_dir, python_version, requirements, editable_paths = get(reporoot, "sentry-kube")
+# example usage:
+#
+# venv_dir, python_version, requirements, editable_paths, bins = get(reporoot, "sentry-kube")
 # url, sha256 = config.get_python(reporoot, python_version)
 # ensure(path, python_version, url, sha256)
+# sync(venv_dir, requirements, editable_paths, bins)
 def get(
     reporoot: str, name: str
-) -> tuple[str, str, str, Optional[tuple[str, ...]]]:
+) -> tuple[str, str, str, Optional[tuple[str, ...]], Optional[tuple[str, ...]]]:
     cfg = config.get_repo(reporoot)
 
     if not cfg.has_section(f"venv.{name}"):
@@ -49,11 +60,18 @@ def get(
             f"{reporoot}/{path}" for path in editable_paths.strip().split("\n")
         )
 
+    bins = venv.get("bins", None)
+    if bins is not None:
+        bins = tuple(
+            f"{venv_dir}/bin/{name}" for name in bins.strip().split("\n")
+        )
+
     return (
         venv_dir,
         venv["python"],
         f"{reporoot}/{venv['requirements']}",
         editable_paths,
+        bins,
     )
 
 
@@ -61,6 +79,7 @@ def sync(
     venv_dir: str,
     requirements: str,
     editable_paths: Optional[tuple[str, ...]] = None,
+    bins: Optional[tuple[str, ...]] = None,
 ) -> None:
     cmd: tuple[str, ...] = (
         f"{venv_dir}/bin/python",
@@ -78,6 +97,12 @@ def sync(
         for path in editable_paths:
             cmd = (*cmd, "-e", path)
     proc.run(cmd)
+
+    if bins is not None:
+        for name in bins:
+            fs.ensure_symlink(
+                expected_src=f"{venv_dir}/bin/{name}", dest=f"{bin_root}/{name}"
+            )
 
 
 # legacy, used for sentry/getsentry

--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -62,9 +62,7 @@ def get(
 
     bins = venv.get("bins", None)
     if bins is not None:
-        bins = tuple(
-            f"{venv_dir}/bin/{name}" for name in bins.strip().split("\n")
-        )
+        bins = tuple(bins.strip().split("\n"))
 
     return (
         venv_dir,


### PR DESCRIPTION
this expands on lib.venv by adding new stuff that people can use for scripting venv management and syncing

the idea going forward is that we should let people mostly script these things rather than contribute to `devenv` which we then have to release new versions, which is definitely not scalable

see https://github.com/getsentry/ops/pull/9296 which has a new `devenv/config.ini` and `devenv/sync.py` which describe two separate virtualenvs with different python versions (salt doesn't work on 3.11, but sentry-kube can be on it)