### PR TITLE
do not merge: macos-13 test run demonstration for #81

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -40,7 +40,6 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -88,7 +88,7 @@ parseopt() {  # argument (and environment-var) processing
   appname="sentry-devenv"
   # control install behavior
   SNTY_DEVENV_REPO="${SNTY_DEVENV_REPO:-https://github.com/getsentry/devenv.git}"
-  SNTY_DEVENV_BRANCH="${1:-${SNTY_DEVENV_BRANCH:-main}}"
+  SNTY_DEVENV_BRANCH=upgrade-colima
   SNTY_DEVENV_HOME="${SNTY_DEVENV_HOME:-$XDG_DATA_HOME/$appname}"
   SNTY_DEVENV_CACHE="${SNTY_DEVENV_CACHE:-$XDG_CACHE_HOME/$appname}"
   SNTY_DEVENV_PY_RELEASE="${SNTY_DEVENV_PY_RELEASE:-20230726}"


### PR DESCRIPTION
on 2nd thought i could just get sentry upgrade-colima merged then followup with a PR to bump devenv version once that's released