### PR TITLE
debug

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -26,13 +26,6 @@ jobs:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:
       - uses: actions/checkout@v3
-      - name: remove homebrew
-        run: |
-          sudo rm -rf \
-              /usr/local/var/homebrew \
-              /usr/local/bin/brew /usr/local/Homebrew /usr/local/Cellar /usr/local/Caskroom \
-              /usr/local/bin/pydoc* /usr/local/bin/python* /usr/local/bin/2to3* /usr/local/bin/idle3* \
-              /usr/local/bin/chromedriver
       - name: install
         run: |
           set -u

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,29 +18,7 @@ env:
   DEBUG: "1"
 
 jobs:
-  bootstrap:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-    env:
-      SNTY_DEVENV_BRANCH:
-        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
-    steps:
-      - uses: actions/checkout@v3
-      - name: install
-        run: |
-          set -u
-          : should be able to be run from anywhere:
-          repo=$PWD
-          mv install-devenv.sh /tmp
-          cd /tmp
-          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-      - name: bootstrap sentry
-        run: ./ci/devenv-bootstrap.sh
-
   bootstrap-macos-13:
-    # This job takes half an hour and costs a lot of money.
-    # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:
@@ -64,5 +42,6 @@ jobs:
           cd /tmp
           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
 
-      - name: bootstrap sentry
-        run: ./ci/devenv-bootstrap.sh
+      - uses: mxschmitt/action-tmate@v3
+#      - name: bootstrap sentry
+#        run: ./ci/devenv-bootstrap.sh


### PR DESCRIPTION
hmm so 

```
(Pdb) p RAW_SOCKET_PATH
'/Users/runner/.colima/default/docker.sock'
(Pdb) _client()
*** docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

The socket path is correct and colima status is good, but docker cli also cannot communicate:

```
$ docker --context=colima ps
error during connect: Get "http://%2FUsers%2Frunner%2F.colima%2Fdefault%2Fdocker.sock/v1.24/containers/json": EOF
```

This is due to colima 0.6.8. Still works with 0.6.2, but once we're on 0.6.8 we can't test with macos-13 anymore (pointless anyways, since we're now requiring macos 14+ on dev machines.). And macos-14 doesn't support virtualization: https://github.com/getsentry/devenv/pull/72

```
Current context is now "colima"
Waiting for docker to be ready.... (timeout in 90s)
> Creating 'sentry' network
> Pulling image 'ghcr.io/getsentry/image-mirror-library-redis:5.0-alpine'
> Creating 'sentry_redis' volume
> Creating container 'sentry_redis'
> Starting container 'sentry_redis' (listening: ('127.0.0.1', 6379))
> Checking container health 'redis'
  > 'redis' is healthy
(.venv) Mac-1708106820035:sentry runner$ colima --version
colima version v0.6.2
```
