### PR TITLE
test: remove macos-13 as it no longer works with colima 0.6.8

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,6 +18,8 @@ env:
   DEBUG: "1"
 
 jobs:
+  # unfortunately, macos-13 and macos-14 do not work
+  # see https://github.com/getsentry/devenv/pull/83
   bootstrap:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -34,35 +36,5 @@ jobs:
           mv install-devenv.sh /tmp
           cd /tmp
           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-      - name: bootstrap sentry
-        run: ./ci/devenv-bootstrap.sh
-
-  bootstrap-macos-13:
-    # This job takes half an hour and costs a lot of money.
-    # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: macos-13
-    timeout-minutes: 60
-    env:
-      SNTY_DEVENV_BRANCH:
-        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
-    steps:
-      - uses: actions/checkout@v3
-      - name: remove homebrew
-        run: |
-          sudo rm -rf \
-              /usr/local/var/homebrew \
-              /usr/local/bin/brew /usr/local/Homebrew /usr/local/Cellar /usr/local/Caskroom \
-              /usr/local/bin/pydoc* /usr/local/bin/python* /usr/local/bin/2to3* /usr/local/bin/idle3* \
-              /usr/local/bin/chromedriver
-      - name: install
-        run: |
-          set -u
-          : should be able to be run from anywhere:
-          repo=$PWD
-          mv install-devenv.sh /tmp
-          cd /tmp
-          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-
       - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh


### PR DESCRIPTION
see https://github.com/getsentry/devenv/pull/83

i need this to unblock a new release that'll get sentry people onto newer better colima 0.6.8

however... should we alternatively run macos-13 + colima 0.6.2 so we can have integration coverage albeit on outdated platform + software?
