### PR TITLE
Fixing spacing between check name and msg

### DIFF
--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -213,7 +213,7 @@ def main(context: Dict[str, str], argv: Sequence[str] | None = None) -> int:
             if ok:
                 print(f"\t\t✅ fix: {check.name}".expandtabs(4))
             else:
-                print(f"\t\t❌ fix: {check.name}{msg}".expandtabs(4))
+                print(f"\t\t❌ fix: {check.name} ({msg})".expandtabs(4))
         else:
             print(f"\t\t⏭️  Skipping {check.name}".expandtabs(4))
             skip.append(check)

--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -139,7 +139,7 @@ def filter_failing_checks(
         if ok:
             print(f"\t✅ check: {check.name}".expandtabs(4))
             continue
-        print(f"\t❌ check: {check.name}{msg}".expandtabs(4))
+        print(f"\t❌ check: {check.name} ({msg})".expandtabs(4))
         failing_checks.append(check)
     return failing_checks
 


### PR DESCRIPTION
Noticed that there was no spacing between the check name and the msg for the doctor.