### PR TITLE
Update type annotations for check and fix functions

### DIFF
--- a/devenv/checks/test.py
+++ b/devenv/checks/test.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
 
 import os
-from typing import Set
-from typing import Tuple
 
 from devenv.lib import fs
 from devenv.lib import proc
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set()
+tags: set[str] = set()
 name = "foo"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     if os.path.exists(f"{fs.gitroot()}/foo"):
         return True, ""
     return False, f"{fs.gitroot()}/foo doesn't exist"
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     try:
         proc.run(
             (

--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -12,8 +12,6 @@ from pkgutil import walk_packages
 from types import ModuleType
 from typing import Dict
 from typing import List
-from typing import Set
-from typing import Tuple
 
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
@@ -25,9 +23,9 @@ class Check:
     """
     A check is a module with the following attributes:
     - name: str
-    - tags: Set[str]
-    - check: Callable[[], Tuple[bool, str]]
-    - fix: Callable[[], Tuple[bool, str]]
+    - tags: set[str]
+    - check: Callable[[], tuple[bool, str]]
+    - fix: Callable[[], tuple[bool, str]]
 
     The check function should return a tuple of (ok, msg).
     The fix function should return a tuple of (ok, msg).
@@ -36,9 +34,9 @@ class Check:
     """
 
     name: str
-    tags: Set[str]
-    check: Callable[[], Tuple[bool, str]]
-    fix: Callable[[], Tuple[bool, str]]
+    tags: set[str]
+    check: Callable[[], tuple[bool, str]]
+    fix: Callable[[], tuple[bool, str]]
 
     def __init__(self, module: ModuleType):
         # Check that the module has the required attributes.
@@ -61,7 +59,7 @@ class Check:
         ), "the `check` attribute must be a function"
         check_hints = typing.get_type_hints(module.check)
         assert (
-            check_hints["return"] == Tuple[bool, str]
+            check_hints["return"] == tuple[bool, str]
         ), "`check(...)` should return a tuple of (bool, str)"
         self.check = checker(module.check)
 
@@ -69,14 +67,14 @@ class Check:
         assert callable(module.fix), "the `fix` attribute should be a function"
         fix_hints = typing.get_type_hints(module.fix)
         assert (
-            fix_hints["return"] == Tuple[bool, str]
+            fix_hints["return"] == tuple[bool, str]
         ), "`fix(...)` should return a tuple of (bool, str)"
         self.fix = fixer(module.fix)
 
         super().__init__()
 
 
-def load_checks(context: Dict[str, str], match_tags: Set[str]) -> List[Check]:
+def load_checks(context: Dict[str, str], match_tags: set[str]) -> List[Check]:
     """
     Load all checks from the checks directory.
     Optionally filter by tags.
@@ -109,7 +107,7 @@ def run_checks(
     checks: List[Check],
     executor: ThreadPoolExecutor,
     skip: Iterable[Check] = (),
-) -> Dict[Check, Tuple[bool, str]]:
+) -> Dict[Check, tuple[bool, str]]:
     """
     Run checks in parallel, and return a dict of results.
     Results are a tuple of (ok, msg).
@@ -130,7 +128,7 @@ def run_checks(
 
 
 def filter_failing_checks(
-    results: Dict[Check, Tuple[bool, str]]
+    results: Dict[Check, tuple[bool, str]]
 ) -> List[Check]:
     """Print a report of the results, and return a list of failing checks."""
     failing_checks: list[Check] = []
@@ -151,7 +149,7 @@ def prompt_for_fix(check: Check) -> bool:
     ).lower() in {"y", "yes", ""}
 
 
-def attempt_fix(check: Check, executor: ThreadPoolExecutor) -> Tuple[bool, str]:
+def attempt_fix(check: Check, executor: ThreadPoolExecutor) -> tuple[bool, str]:
     """Attempt to fix a check, and return a tuple of (ok, msg)."""
     future = executor.submit(check.fix)
     try:

--- a/devenv/lib_check/types.py
+++ b/devenv/lib_check/types.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Tuple
 
 
 def checker(
-    f: Callable[[], Tuple[bool, str]]
-) -> Callable[[], Tuple[bool, str]]:
+    f: Callable[[], tuple[bool, str]]
+) -> Callable[[], tuple[bool, str]]:
     return f
 
 
-def fixer(f: Callable[[], Tuple[bool, str]]) -> Callable[[], Tuple[bool, str]]:
+def fixer(f: Callable[[], tuple[bool, str]]) -> Callable[[], tuple[bool, str]]:
     return f

--- a/tests/doctor/devenv/checks/bad_check.py
+++ b/tests/doctor/devenv/checks/bad_check.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "bad"])
+tags: set[str] = set(["test", "bad"])
 name = "bad check"
 
 
 @checker  # type: ignore # intended error
-def check() -> Tuple[str, str]:
+def check() -> tuple[str, str]:
     return "True", ""
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     return True, ""

--- a/tests/doctor/devenv/checks/bad_fix.py
+++ b/tests/doctor/devenv/checks/bad_fix.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "bad"])
+tags: set[str] = set(["test", "bad"])
 name = "bad fix"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return True, ""
 
 
 @fixer  # type: ignore  # intended error
-def fix() -> Tuple[str, str]:
+def fix() -> tuple[str, str]:
     return "True", ""

--- a/tests/doctor/devenv/checks/broken_check.py
+++ b/tests/doctor/devenv/checks/broken_check.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "broken"])
+tags: set[str] = set(["test", "broken"])
 name = "broken check"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     # This is a broken check, it will raise an exception
     a = 1 / 0
     return True, f"{a}"
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     return True, ""

--- a/tests/doctor/devenv/checks/broken_fix.py
+++ b/tests/doctor/devenv/checks/broken_fix.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "broken"])
+tags: set[str] = set(["test", "broken"])
 name = "broken fix"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return True, ""
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     # This is a broken fix, it will raise an exception
     a = 1 / 0
     return True, f"{a}"

--- a/tests/doctor/devenv/checks/failing_check.py
+++ b/tests/doctor/devenv/checks/failing_check.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "fail"])
+tags: set[str] = set(["test", "fail"])
 name = "failing check"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return False, ""
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     return False, ""

--- a/tests/doctor/devenv/checks/failing_check_with_msg.py
+++ b/tests/doctor/devenv/checks/failing_check_with_msg.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "fail"])
+tags: set[str] = set(["test", "fail"])
 name = "failing check with msg"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return False, "check failed"
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     return False, "fix failed"

--- a/tests/doctor/devenv/checks/no_check.py
+++ b/tests/doctor/devenv/checks/no_check.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
 
-from typing import Set
-
-tags: Set[str] = set()
+tags: set[str] = set()
 name = "no check"

--- a/tests/doctor/devenv/checks/no_name.py
+++ b/tests/doctor/devenv/checks/no_name.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 
-tags: Set[str] = set()
+tags: set[str] = set()
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return True, ""

--- a/tests/doctor/devenv/checks/no_tags.py
+++ b/tests/doctor/devenv/checks/no_tags.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 
 name = "no tags"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return True, ""

--- a/tests/doctor/devenv/checks/passing_check.py
+++ b/tests/doctor/devenv/checks/passing_check.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import Set
-from typing import Tuple
-
 from devenv.lib_check.types import checker
 from devenv.lib_check.types import fixer
 
-tags: Set[str] = set(["test", "pass"])
+tags: set[str] = set(["test", "pass"])
 name = "passing check"
 
 
 @checker
-def check() -> Tuple[bool, str]:
+def check() -> tuple[bool, str]:
     return True, ""
 
 
 @fixer
-def fix() -> Tuple[bool, str]:
+def fix() -> tuple[bool, str]:
     return True, ""


### PR DESCRIPTION
Refactoring usages of `typing.Set` and `typing.Tuple` to use built-in `tuple` and `set`, which is now possible in python 3.9+.