### PR TITLE
ref: Don't require your own version of direnv

### DIFF
--- a/devenv/lib/direnv.py
+++ b/devenv/lib/direnv.py
@@ -24,7 +24,7 @@ _sha256 = {
 def install() -> None:
     direnv_path = f"{root}/bin/direnv"
 
-    if shutil.which("direnv") == direnv_path:
+    if shutil.which("direnv") is not None:
         return
 
     machine = "arm64" if MACHINE == "arm64" else "amd64"


### PR DESCRIPTION
`devenv`checks whether `direnv` is already installed under its binary path (`~/.local/share/sentry-devenv/bin`) and installs it otherwise, which also involves modifying the shell rc file. This means that even if you already have `direnv` installed, `devenv` will try to install it anyway. There's no obvious reason why `devenv` should require `direnv` under a specific path, and in my case, this actually causes a problem because my shell rc file is readonly.