### PR TITLE
allow invoking devenv as `python -m devenv`

### DIFF
--- a/devenv/__main__.py
+++ b/devenv/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from devenv.main import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
this makes it easier to rerun ourselves in a subprocess reliably (independent of PATH)