### PR TITLE
feat: repo local bins

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: devenv-repo-local-bins
+      SENTRY_BRANCH: master
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:
@@ -46,7 +46,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: devenv-repo-local-bins
+      SENTRY_BRANCH: master
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -42,7 +42,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: master
+      SENTRY_BRANCH: devenv-repo-local-bins
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:
@@ -42,11 +42,11 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: master
+      SENTRY_BRANCH: devenv-repo-local-bins
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -12,7 +12,6 @@ from devenv.constants import DARWIN
 from devenv.constants import EXTERNAL_CONTRIBUTOR
 from devenv.constants import home
 from devenv.constants import homebrew_bin
-from devenv.constants import VOLTA_HOME
 from devenv.lib import brew
 from devenv.lib import direnv
 from devenv.lib import github
@@ -186,10 +185,7 @@ When done, hit ENTER to continue.
             # eventually we should move this bootstrap testing over to getsentry repo
             proc.run(
                 ("make", "bootstrap"),
-                env={
-                    "VIRTUAL_ENV": f"{coderoot}/getsentry/.venv",
-                    "VOLTA_HOME": VOLTA_HOME,
-                },
+                env={"VIRTUAL_ENV": f"{coderoot}/getsentry/.venv"},
                 pathprepend=f"{coderoot}/getsentry/.venv/bin",
                 cwd=f"{coderoot}/getsentry",
             )

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -165,7 +165,7 @@ When done, hit ENTER to continue.
         proc.run(
             ("make", "bootstrap"),
             env={"VIRTUAL_ENV": f"{coderoot}/sentry/.venv"},
-            pathprepend=f"{coderoot}/sentry/.venv/bin",
+            pathprepend=f"{coderoot}/sentry/.devenv/bin:{coderoot}/sentry/.venv/bin",
             cwd=f"{coderoot}/sentry",
         )
 
@@ -184,7 +184,7 @@ When done, hit ENTER to continue.
             proc.run(
                 ("make", "bootstrap"),
                 env={"VIRTUAL_ENV": f"{coderoot}/getsentry/.venv"},
-                pathprepend=f"{coderoot}/getsentry/.venv/bin",
+                pathprepend=f"{coderoot}/getsentry/.devenv/bin:{coderoot}/getsentry/.venv/bin",
                 cwd=f"{coderoot}/getsentry",
             )
 

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -16,7 +16,6 @@ from devenv.lib import brew
 from devenv.lib import direnv
 from devenv.lib import github
 from devenv.lib import proc
-from devenv.lib import volta
 
 help = "Bootstraps the development environment."
 ExitCode: TypeAlias = "str | int | None"
@@ -88,7 +87,6 @@ When done, hit ENTER to continue.
             )
 
     brew.install()
-    volta.install()
     direnv.install()
 
     os.makedirs(coderoot, exist_ok=True)

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -27,7 +27,6 @@ user_environ: typing.Mapping[str, str] = os.environ.copy()
 
 home = user_environ["HOME"] if CI else struct_passwd.pw_dir
 root = f"{home}/.local/share/sentry-devenv"
-bin_root = f"{root}/bin"
 
 homebrew_repo = "/opt/homebrew"
 homebrew_bin = f"{homebrew_repo}/bin"

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -33,3 +33,7 @@ homebrew_bin = f"{homebrew_repo}/bin"
 if INTEL_MAC:
     homebrew_repo = "/usr/local/Homebrew"
     homebrew_bin = "/usr/local/bin"
+
+# compatibility with devenv <= 1.4.0
+# (used in sentry sync.py)
+VOLTA_HOME = f"{root}/volta"

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -27,6 +27,7 @@ user_environ: typing.Mapping[str, str] = os.environ.copy()
 
 home = user_environ["HOME"] if CI else struct_passwd.pw_dir
 root = f"{home}/.local/share/sentry-devenv"
+bin_root = f"{root}/bin"
 
 homebrew_repo = "/opt/homebrew"
 homebrew_bin = f"{homebrew_repo}/bin"

--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -33,5 +33,3 @@ homebrew_bin = f"{homebrew_repo}/bin"
 if INTEL_MAC:
     homebrew_repo = "/usr/local/Homebrew"
     homebrew_bin = "/usr/local/bin"
-
-VOLTA_HOME = f"{root}/volta"

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -32,9 +32,10 @@ def download(url: str, sha256: str, dest: str = "") -> str:
         except HTTPError as e:
             raise RuntimeError(f"Error getting {url}: {e}")
 
-        with tempfile.NamedTemporaryFile(
-            delete=False, dir=os.path.dirname(dest)
-        ) as tmpf:
+        dest_dir = os.path.dirname(dest)
+        os.makedirs(dest_dir, exist_ok=True)
+
+        with tempfile.NamedTemporaryFile(delete=False, dir=dest_dir) as tmpf:
             shutil.copyfileobj(resp, tmpf)
             tmpf.seek(0)
             checksum = hashlib.sha256()

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from typing import Optional
 
 from devenv.constants import home
+from devenv.constants import root
 from devenv.lib import archive
 from devenv.lib import proc
 
@@ -26,7 +28,13 @@ def uninstall(bin_root: str) -> None:
             os.remove(f)
 
 
-def install(version: str, url: str, sha256: str, bin_root: str) -> None:
+def install(
+    version: str, url: str, sha256: str, bin_root: Optional[str] = ""
+) -> None:
+    if not bin_root:
+        # compatibility with devenv <= 1.4.0
+        bin_root = f"{root}/bin"
+
     if shutil.which("colima", path=bin_root) == f"{bin_root}/colima":
         stdout = proc.run((f"{bin_root}/colima", "--version"), stdout=True)
         installed_version = stdout.strip().split()[-1]

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -8,6 +8,7 @@ from typing import Optional
 from devenv.constants import home
 from devenv.constants import root
 from devenv.lib import archive
+from devenv.lib import fs
 from devenv.lib import proc
 
 
@@ -19,33 +20,36 @@ def _install(url: str, sha256: str, into: str) -> None:
         os.chmod(f"{into}/colima", 0o775)
 
 
-def uninstall(bin_root: str) -> None:
+def uninstall(binroot: str) -> None:
     for d in (f"{home}/.lima",):
         shutil.rmtree(d, ignore_errors=True)
 
-    for f in (f"{bin_root}/colima",):
+    for f in (f"{binroot}/colima",):
         if os.path.exists(f):
             os.remove(f)
 
 
 def install(
-    version: str, url: str, sha256: str, bin_root: Optional[str] = ""
+    version: str, url: str, sha256: str, reporoot: Optional[str] = ""
 ) -> None:
-    if not bin_root:
+    if reporoot:
+        binroot = fs.ensure_binroot(reporoot)
+    else:
         # compatibility with devenv <= 1.4.0
-        bin_root = f"{root}/bin"
+        binroot = f"{root}/bin"
+        os.makedirs(binroot, exist_ok=True)
 
-    if shutil.which("colima", path=bin_root) == f"{bin_root}/colima":
-        stdout = proc.run((f"{bin_root}/colima", "--version"), stdout=True)
+    if shutil.which("colima", path=binroot) == f"{binroot}/colima":
+        stdout = proc.run((f"{binroot}/colima", "--version"), stdout=True)
         installed_version = stdout.strip().split()[-1]
         if version == installed_version:
             return
         print(f"installed colima {installed_version} is outdated!")
 
     print(f"installing colima {version}...")
-    uninstall(bin_root)
-    _install(url, sha256, bin_root)
+    uninstall(binroot)
+    _install(url, sha256, binroot)
 
-    stdout = proc.run((f"{bin_root}/colima", "--version"), stdout=True)
+    stdout = proc.run((f"{binroot}/colima", "--version"), stdout=True)
     if f"colima version {version}" not in stdout:
         raise SystemExit(f"Failed to install colima {version}! Found: {stdout}")

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -4,20 +4,20 @@ import os
 import shutil
 import tempfile
 
-from devenv.constants import bin_root
 from devenv.constants import home
 from devenv.lib import archive
 from devenv.lib import proc
 
 
 def _install(url: str, sha256: str, into: str) -> None:
+    os.makedirs(into, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=into) as tmpd:
         archive.download(url, sha256, dest=f"{tmpd}/colima")
         os.replace(f"{tmpd}/colima", f"{into}/colima")
         os.chmod(f"{into}/colima", 0o775)
 
 
-def uninstall() -> None:
+def uninstall(bin_root: str) -> None:
     for d in (f"{home}/.lima",):
         shutil.rmtree(d, ignore_errors=True)
 
@@ -26,7 +26,7 @@ def uninstall() -> None:
             os.remove(f)
 
 
-def install(version: str, url: str, sha256: str) -> None:
+def install(version: str, url: str, sha256: str, bin_root: str) -> None:
     if shutil.which("colima", path=bin_root) == f"{bin_root}/colima":
         stdout = proc.run((f"{bin_root}/colima", "--version"), stdout=True)
         installed_version = stdout.strip().split()[-1]
@@ -35,7 +35,7 @@ def install(version: str, url: str, sha256: str) -> None:
         print(f"installed colima {installed_version} is outdated!")
 
     print(f"installing colima {version}...")
-    uninstall()
+    uninstall(bin_root)
     _install(url, sha256, bin_root)
 
     stdout = proc.run((f"{bin_root}/colima", "--version"), stdout=True)

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -49,8 +49,13 @@ def write_script(filepath: str, text: str) -> None:
 def ensure_binroot(reporoot: str) -> str:
     binroot = f"{reporoot}/.devenv/bin"
     os.makedirs(binroot, exist_ok=True)
-    with open(f"{binroot}/.gitignore", "w") as f:
-        f.write("*")
+    if not os.path.exists(f"{binroot}/.gitignore"):
+        with open(f"{binroot}/.gitignore", "w") as f:
+            f.write(
+                """*
+# automatically written by devenv ensure_binroot! feel free to modify.
+"""
+            )
     return binroot
 
 

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -50,7 +50,7 @@ def ensure_binroot(reporoot: str) -> str:
     binroot = f"{reporoot}/.devenv/bin"
     os.makedirs(binroot, exist_ok=True)
     with open(f"{binroot}/.gitignore", "w") as f:
-        f.write("'*'")
+        f.write("*")
     return binroot
 
 

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -46,6 +46,14 @@ def write_script(filepath: str, text: str) -> None:
     os.chmod(filepath, 0o775)
 
 
+def ensure_binroot(reporoot: str) -> str:
+    binroot = f"{reporoot}/.devenv/bin"
+    os.makedirs(binroot, exist_ok=True)
+    with open(f"{binroot}/.gitignore", "w") as f:
+        f.write("'*'")
+    return binroot
+
+
 def ensure_symlink(expected_src: str, dest: str) -> None:
     try:
         src = os.readlink(dest)

--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import tempfile
 
-from devenv.constants import bin_root
 from devenv.constants import root
 from devenv.lib import archive
 from devenv.lib import fs
@@ -12,6 +11,7 @@ from devenv.lib import proc
 
 
 def _install(url: str, sha256: str, into: str) -> None:
+    os.makedirs(into, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=into) as tmpd:
         archive_file = archive.download(url, sha256, dest=f"{tmpd}/download")
         archive.unpack(archive_file, tmpd)
@@ -38,7 +38,7 @@ exec /usr/bin/env CLOUDSDK_PYTHON={root}/python/bin/python3 PATH={into}/google-c
     )
 
 
-def uninstall() -> None:
+def uninstall(bin_root: str) -> None:
     for d in (f"{bin_root}/google-cloud-sdk",):
         shutil.rmtree(d, ignore_errors=True)
 
@@ -47,7 +47,7 @@ def uninstall() -> None:
             os.remove(f)
 
 
-def install(version: str, url: str, sha256: str) -> None:
+def install(version: str, url: str, sha256: str, bin_root: str) -> None:
     if (
         shutil.which("gcloud", path=bin_root) == f"{bin_root}/gcloud"
         and shutil.which("gsutil", path=bin_root) == f"{bin_root}/gsutil"
@@ -59,7 +59,7 @@ def install(version: str, url: str, sha256: str) -> None:
             print(f"installed gcloud {installed_version} is outdated!")
 
     print(f"installing gcloud {version}...")
-    uninstall()
+    uninstall(bin_root)
     _install(url, sha256, bin_root)
 
     proc.run(

--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -38,33 +38,35 @@ exec /usr/bin/env CLOUDSDK_PYTHON={root}/python/bin/python3 PATH={into}/google-c
     )
 
 
-def uninstall(bin_root: str) -> None:
-    for d in (f"{bin_root}/google-cloud-sdk",):
+def uninstall(binroot: str) -> None:
+    for d in (f"{binroot}/google-cloud-sdk",):
         shutil.rmtree(d, ignore_errors=True)
 
-    for f in (f"{bin_root}/gcloud", f"{bin_root}/gsutil"):
+    for f in (f"{binroot}/gcloud", f"{binroot}/gsutil"):
         if os.path.exists(f):
             os.remove(f)
 
 
-def install(version: str, url: str, sha256: str, bin_root: str) -> None:
+def install(version: str, url: str, sha256: str, reporoot: str) -> None:
+    binroot = fs.ensure_binroot(reporoot)
+
     if (
-        shutil.which("gcloud", path=bin_root) == f"{bin_root}/gcloud"
-        and shutil.which("gsutil", path=bin_root) == f"{bin_root}/gsutil"
+        shutil.which("gcloud", path=binroot) == f"{binroot}/gcloud"
+        and shutil.which("gsutil", path=binroot) == f"{binroot}/gsutil"
     ):
-        with open(f"{bin_root}/google-cloud-sdk/VERSION", "r") as f:
+        with open(f"{binroot}/google-cloud-sdk/VERSION", "r") as f:
             installed_version = f.read().strip()
             if version == installed_version:
                 return
             print(f"installed gcloud {installed_version} is outdated!")
 
     print(f"installing gcloud {version}...")
-    uninstall(bin_root)
-    _install(url, sha256, bin_root)
+    uninstall(binroot)
+    _install(url, sha256, binroot)
 
     proc.run(
         (
-            f"{bin_root}/gcloud",
+            f"{binroot}/gcloud",
             "components",
             "install",
             "-q",
@@ -73,6 +75,6 @@ def install(version: str, url: str, sha256: str, bin_root: str) -> None:
         )
     )
 
-    stdout = proc.run((f"{bin_root}/gcloud", "--version"), stdout=True)
+    stdout = proc.run((f"{binroot}/gcloud", "--version"), stdout=True)
     if "gke-gcloud-auth-plugin" not in stdout:
         raise SystemExit("Failed to install gcloud {version}!")

--- a/devenv/lib/limactl.py
+++ b/devenv/lib/limactl.py
@@ -4,8 +4,10 @@ import os
 import platform
 import tempfile
 from shutil import which
+from typing import Optional
 
 from devenv.constants import MACHINE
+from devenv.constants import root
 from devenv.lib import archive
 
 _version = "0.19.1"
@@ -70,7 +72,11 @@ def _install(into: str) -> None:
         )
 
 
-def install(bin_root: str) -> None:
+def install(bin_root: Optional[str] = "") -> None:
+    if not bin_root:
+        # compatibility with devenv <= 1.4.0
+        bin_root = f"{root}/bin"
+
     # this needs to be better
     if (
         which("lima", path=bin_root) == f"{bin_root}/lima"

--- a/devenv/lib/limactl.py
+++ b/devenv/lib/limactl.py
@@ -9,6 +9,7 @@ from typing import Optional
 from devenv.constants import MACHINE
 from devenv.constants import root
 from devenv.lib import archive
+from devenv.lib import fs
 
 _version = "0.19.1"
 _sha256 = {
@@ -72,21 +73,25 @@ def _install(into: str) -> None:
         )
 
 
-def install(bin_root: Optional[str] = "") -> None:
-    if not bin_root:
+def install(reporoot: Optional[str] = "") -> None:
+    if reporoot:
+        binroot = fs.ensure_binroot(reporoot)
+    else:
         # compatibility with devenv <= 1.4.0
-        bin_root = f"{root}/bin"
+        binroot = f"{root}/bin"
+        os.makedirs(binroot, exist_ok=True)
 
     # this needs to be better
     if (
-        which("lima", path=bin_root) == f"{bin_root}/lima"
-        and which("limactl", path=bin_root) == f"{bin_root}/limactl"
+        which("lima", path=binroot) == f"{binroot}/lima"
+        and which("limactl", path=binroot) == f"{binroot}/limactl"
     ):
         return
 
-    _install(bin_root)
+    # TODO: uninstall and repolocal config for versions
+    _install(binroot)
 
-    if not os.path.exists(f"{bin_root}/lima") or not os.path.exists(
-        f"{bin_root}/limactl"
+    if not os.path.exists(f"{binroot}/lima") or not os.path.exists(
+        f"{binroot}/limactl"
     ):
         raise SystemExit("Failed to install colima!")

--- a/devenv/lib/limactl.py
+++ b/devenv/lib/limactl.py
@@ -5,7 +5,6 @@ import platform
 import tempfile
 from shutil import which
 
-from devenv.constants import bin_root
 from devenv.constants import MACHINE
 from devenv.lib import archive
 
@@ -71,7 +70,7 @@ def _install(into: str) -> None:
         )
 
 
-def install() -> None:
+def install(bin_root: str) -> None:
     # this needs to be better
     if (
         which("lima", path=bin_root) == f"{bin_root}/lima"

--- a/devenv/lib/proc.py
+++ b/devenv/lib/proc.py
@@ -13,15 +13,9 @@ from devenv.constants import homebrew_bin
 from devenv.constants import root
 from devenv.constants import shell_path
 from devenv.constants import user_environ
-from devenv.constants import VOLTA_HOME
 
-base_path = f"{root}/bin:{VOLTA_HOME}/bin:{homebrew_bin}:{user_environ['PATH']}"
-base_env = {
-    "PATH": base_path,
-    "HOME": home,
-    "SHELL": shell_path,
-    "VOLTA_HOME": VOLTA_HOME,
-}
+base_path = f"{root}/bin:{homebrew_bin}:{user_environ['PATH']}"
+base_env = {"PATH": base_path, "HOME": home, "SHELL": shell_path}
 
 
 def quote(cmd: tuple[str, ...]) -> str:

--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -95,8 +95,7 @@ def sync(
     proc.run(cmd)
 
     if bins is not None:
-        binroot = f"{reporoot}/.devenv/bin"
-        os.makedirs(binroot, exist_ok=True)
+        binroot = fs.ensure_binroot(reporoot)
         for name in bins:
             fs.ensure_symlink(
                 expected_src=f"{venv_dir}/bin/{name}", dest=f"{binroot}/{name}"

--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -6,7 +6,6 @@ from enum import Enum
 from typing import Optional
 
 from devenv import pythons
-from devenv.constants import bin_root
 from devenv.lib import config
 from devenv.lib import fs
 from devenv.lib import proc
@@ -41,7 +40,7 @@ VenvStatus = Enum(
 # venv_dir, python_version, requirements, editable_paths, bins = get(reporoot, "sentry-kube")
 # url, sha256 = config.get_python(reporoot, python_version)
 # ensure(path, python_version, url, sha256)
-# sync(venv_dir, requirements, editable_paths, bins)
+# sync(reporoot, venv_dir, requirements, editable_paths, bins)
 def get(
     reporoot: str, name: str
 ) -> tuple[str, str, str, Optional[tuple[str, ...]], Optional[tuple[str, ...]]]:
@@ -72,6 +71,7 @@ def get(
 
 
 def sync(
+    reporoot: str,
     venv_dir: str,
     requirements: str,
     editable_paths: Optional[tuple[str, ...]] = None,
@@ -95,9 +95,11 @@ def sync(
     proc.run(cmd)
 
     if bins is not None:
+        binroot = f"{reporoot}/.devenv/bin"
+        os.makedirs(binroot, exist_ok=True)
         for name in bins:
             fs.ensure_symlink(
-                expected_src=f"{venv_dir}/bin/{name}", dest=f"{bin_root}/{name}"
+                expected_src=f"{venv_dir}/bin/{name}", dest=f"{binroot}/{name}"
             )
 
 

--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -74,7 +74,7 @@ def populate_volta_home_with_shims(unpack_into: str, volta_home: str) -> None:
 def install(reporoot: Optional[str] = "") -> None:
     if reporoot:
         binroot = fs.ensure_binroot(reporoot)
-        VOLTA_HOME = f"{binroot}/../volta"
+        VOLTA_HOME = f"{binroot}/volta-home"
     else:
         # compatibility with devenv <= 1.4.0
         binroot = f"{root}/bin"

--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import os
 import platform
 from shutil import which
+from typing import Optional
 
 from devenv.constants import homebrew_bin
 from devenv.constants import root
-from devenv.constants import VOLTA_HOME
 from devenv.lib import archive
+from devenv.lib import fs
 from devenv.lib import proc
 
 _version = "1.1.1"
@@ -58,30 +59,42 @@ def install_volta(unpack_into: str) -> None:
     download_and_unpack_archive(name, unpack_into)
 
 
-def populate_volta_home_with_shims(unpack_into: str) -> None:
+def populate_volta_home_with_shims(unpack_into: str, volta_home: str) -> None:
     # executing volta -v will populate the VOLTA_HOME directory
     # with node/npm/yarn shims
-    proc.run((f"{unpack_into}/volta-migrate",))
-    version = proc.run((f"{unpack_into}/volta", "-v"), stdout=True)
+    proc.run((f"{unpack_into}/volta-migrate",), env={"VOLTA_HOME": volta_home})
+    version = proc.run(
+        (f"{unpack_into}/volta", "-v"),
+        env={"VOLTA_HOME": volta_home},
+        stdout=True,
+    )
     assert version == _version, (version, _version)
 
 
-def install() -> None:
-    unpack_into = f"{root}/bin"
+def install(reporoot: Optional[str] = "") -> None:
+    if reporoot:
+        binroot = fs.ensure_binroot(reporoot)
+        VOLTA_HOME = f"{binroot}/../volta"
+    else:
+        # compatibility with devenv <= 1.4.0
+        binroot = f"{root}/bin"
+        os.makedirs(binroot, exist_ok=True)
+        VOLTA_HOME = f"{root}/volta"
 
     if (
-        which("volta", path=f"{root}/bin") == f"{root}/bin/volta"
+        which("volta", path=binroot) == f"{binroot}/volta"
         and which("node", path=f"{VOLTA_HOME}/bin") == f"{VOLTA_HOME}/bin/node"
-        and os.path.exists(f"{root}/bin/node")
-        and os.readlink(f"{root}/bin/node") == f"{VOLTA_HOME}/bin/node"
+        and os.path.exists(f"{binroot}/node")
+        and os.readlink(f"{binroot}/node") == f"{VOLTA_HOME}/bin/node"
     ):
         return
 
-    install_volta(unpack_into)
-    populate_volta_home_with_shims(unpack_into)
+    # TODO(josh): uninstall
+    install_volta(binroot)
+    populate_volta_home_with_shims(binroot, VOLTA_HOME)
 
     if not os.path.exists(f"{VOLTA_HOME}/bin/node"):
         raise SystemExit("Failed to install volta!")
 
     for executable in ("node", "npm", "npx", "yarn", "pnpm"):
-        os.symlink(f"{VOLTA_HOME}/bin/{executable}", f"{root}/bin/{executable}")
+        os.symlink(f"{VOLTA_HOME}/bin/{executable}", f"{binroot}/{executable}")

--- a/tests/lib/test_direnv.py
+++ b/tests/lib/test_direnv.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from unittest.mock import call
 from unittest.mock import patch
 
-from devenv.constants import bin_root
 from devenv.constants import home
+from devenv.constants import root
 from devenv.lib.direnv import _sha256
 from devenv.lib.direnv import _version
 from devenv.lib.direnv import install
@@ -33,9 +33,9 @@ def test_install() -> None:
             call(
                 f"https://github.com/direnv/direnv/releases/download/v{_version}/direnv.darwin-arm64",
                 _sha256["direnv.darwin-arm64"],
-                dest=f"{bin_root}/direnv",
+                dest=f"{root}/bin/direnv",
             )
         ]
         assert mock_proc_run.mock_calls == [
-            call((f"{bin_root}/direnv", "version"), stdout=True)
+            call((f"{root}/bin/direnv", "version"), stdout=True)
         ]


### PR DESCRIPTION
This factors out bin_root, and moves bins like volta and colima into repolocal. This is pretty important as it'll avoid collisions with more than one repo. Honestly should have done this from the very beginning 😰 

since direnv will be used to put this on path and it's pretty stable, it remains in the global bin dir

volta covered by integration
colima/lima covered by integration in gha macos

gcloud and sync.sync are used by ops, no integration coverage yet