### PR TITLE
ref: fully contain VOLTA_HOME

### DIFF
--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -24,9 +24,14 @@ def uninstall(binroot: str) -> None:
     for d in (f"{home}/.lima",):
         shutil.rmtree(d, ignore_errors=True)
 
-    for f in (f"{binroot}/colima",):
-        if os.path.exists(f):
-            os.remove(f)
+    for fp in (f"{binroot}/colima",):
+        try:
+            os.remove(fp)
+        except FileNotFoundError:
+            # it's better to do this than to guard with
+            # os.path.exists(fp) because if it's an invalid or circular
+            # symlink the result'll be False!
+            pass
 
 
 def install(

--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -42,9 +42,14 @@ def uninstall(binroot: str) -> None:
     for d in (f"{binroot}/google-cloud-sdk",):
         shutil.rmtree(d, ignore_errors=True)
 
-    for f in (f"{binroot}/gcloud", f"{binroot}/gsutil"):
-        if os.path.exists(f):
-            os.remove(f)
+    for fp in (f"{binroot}/gcloud", f"{binroot}/gsutil"):
+        try:
+            os.remove(fp)
+        except FileNotFoundError:
+            # it's better to do this than to guard with
+            # os.path.exists(fp) because if it's an invalid or circular
+            # symlink the result'll be False!
+            pass
 
 
 def install(version: str, url: str, sha256: str, reporoot: str) -> None:

--- a/devenv/lib/tenv.py
+++ b/devenv/lib/tenv.py
@@ -54,13 +54,18 @@ def uninstall(binroot: str) -> None:
     for d in (f"{binroot}/tenv-root",):
         shutil.rmtree(d, ignore_errors=True)
 
-    for f in (
+    for fp in (
         f"{binroot}/tenv",
         f"{binroot}/terraform",
         f"{binroot}/terragrunt",
     ):
-        if os.path.exists(f):
-            os.remove(f)
+        try:
+            os.remove(fp)
+        except FileNotFoundError:
+            # it's better to do this than to guard with
+            # os.path.exists(fp) because if it's an invalid or circular
+            # symlink the result'll be False!
+            pass
 
 
 def _version(binpath: str) -> str:

--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -76,8 +76,13 @@ def uninstall(binroot: str, volta_home: str) -> None:
 
     for executable in ("node", "npm", "npx", "yarn", "pnpm"):
         fp = f"{binroot}/{executable}"
-        if os.path.exists(fp):
+        try:
             os.remove(fp)
+        except FileNotFoundError:
+            # it's better to do this than to guard with
+            # os.path.exists(fp) because if it's an invalid or circular
+            # symlink the result'll be False!
+            pass
 
 
 def install(reporoot: Optional[str] = "") -> None:
@@ -95,6 +100,8 @@ def install(reporoot: Optional[str] = "") -> None:
         and shutil.which("node", path=f"{VOLTA_HOME}/bin")
         == f"{VOLTA_HOME}/bin/node"
         and os.path.exists(f"{binroot}/node")
+        # <= 1.6.0 had symlinks, now we have VOLTA_HOME shims
+        and not os.path.islink(f"{binroot}/node")
     ):
         return
 

--- a/devenv/lib/volta.py
+++ b/devenv/lib/volta.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import platform
-from shutil import which
+import shutil
 from typing import Optional
 
 from devenv.constants import homebrew_bin
@@ -52,7 +52,7 @@ def download_and_unpack_archive(name: str, unpack_into: str) -> None:
     archive.unpack(archive_file, unpack_into)
 
 
-def install_volta(unpack_into: str) -> None:
+def _install(unpack_into: str) -> None:
     name = determine_platform(unpack_into)
     if name is None:
         return
@@ -71,6 +71,15 @@ def populate_volta_home_with_shims(unpack_into: str, volta_home: str) -> None:
     assert version == _version, (version, _version)
 
 
+def uninstall(binroot: str, volta_home: str) -> None:
+    shutil.rmtree(volta_home, ignore_errors=True)
+
+    for executable in ("node", "npm", "npx", "yarn", "pnpm"):
+        fp = f"{binroot}/{executable}"
+        if os.path.exists(fp):
+            os.remove(fp)
+
+
 def install(reporoot: Optional[str] = "") -> None:
     if reporoot:
         binroot = fs.ensure_binroot(reporoot)
@@ -82,19 +91,28 @@ def install(reporoot: Optional[str] = "") -> None:
         VOLTA_HOME = f"{root}/volta"
 
     if (
-        which("volta", path=binroot) == f"{binroot}/volta"
-        and which("node", path=f"{VOLTA_HOME}/bin") == f"{VOLTA_HOME}/bin/node"
+        shutil.which("volta", path=binroot) == f"{binroot}/volta"
+        and shutil.which("node", path=f"{VOLTA_HOME}/bin")
+        == f"{VOLTA_HOME}/bin/node"
         and os.path.exists(f"{binroot}/node")
-        and os.readlink(f"{binroot}/node") == f"{VOLTA_HOME}/bin/node"
     ):
         return
 
-    # TODO(josh): uninstall
-    install_volta(binroot)
+    print(f"installing volta {_version}...")
+    uninstall(binroot, VOLTA_HOME)
+    _install(binroot)
     populate_volta_home_with_shims(binroot, VOLTA_HOME)
 
     if not os.path.exists(f"{VOLTA_HOME}/bin/node"):
         raise SystemExit("Failed to install volta!")
 
     for executable in ("node", "npm", "npx", "yarn", "pnpm"):
-        os.symlink(f"{VOLTA_HOME}/bin/{executable}", f"{binroot}/{executable}")
+        # This forces these repo-local bins to use the repo-local
+        # volta home for full containment. Otherwise, the default
+        # is to use ~/.volta.
+        fs.write_script(
+            f"{binroot}/{executable}",
+            f"""#!/bin/sh
+    exec /usr/bin/env VOLTA_HOME={VOLTA_HOME} {VOLTA_HOME}/bin/{executable} "$@"
+""",
+        )

--- a/tests/lib/test_volta.py
+++ b/tests/lib/test_volta.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
+from devenv.lib.volta import _install
 from devenv.lib.volta import _sha256
 from devenv.lib.volta import _version
 from devenv.lib.volta import install
-from devenv.lib.volta import install_volta
 from devenv.lib.volta import populate_volta_home_with_shims
 from devenv.lib.volta import UnexpectedPlatformError
 
@@ -23,7 +23,7 @@ def test_install(tmp_path: str) -> None:
         open(f"{VOLTA_HOME}/bin/{executable}", "a").close()
 
     with patch("devenv.lib.volta.which", side_effect=[None, None]), patch(
-        "devenv.lib.volta.install_volta"
+        "devenv.lib.volta._install"
     ) as mock_install_volta, patch(
         "devenv.lib.volta.proc.run",
         side_effect=[None, _version],  # volta-migrate  # volta -v
@@ -42,7 +42,7 @@ def test_install(tmp_path: str) -> None:
         assert os.readlink(f"{binroot}/node") == f"{VOLTA_HOME}/bin/node"
 
     # now test already installed
-    with patch("devenv.lib.volta.install_volta") as mock_install_volta, patch(
+    with patch("devenv.lib.volta._install") as mock_install_volta, patch(
         "devenv.lib.volta.which",
         side_effect=[f"{binroot}/volta", f"{VOLTA_HOME}/bin/node"],
     ):
@@ -58,7 +58,7 @@ def test_install_volta_linux_x86_64() -> None:
     ) as mock_download, patch(
         "devenv.lib.volta.archive.unpack"
     ) as mock_unpack:
-        install_volta("/path/to/unpack")
+        _install("/path/to/unpack")
         mock_system.assert_called_once()
         mock_machine.assert_called_once()
         mock_download.assert_called_once_with(
@@ -81,7 +81,7 @@ def test_install_volta_macos_x86_64() -> None:
     ) as mock_download, patch(
         "devenv.lib.volta.archive.unpack"
     ) as mock_unpack:
-        install_volta("/path/to/unpack")
+        _install("/path/to/unpack")
         mock_system.assert_called_once()
         mock_machine.assert_called_once()
         mock_download.assert_called_once_with(
@@ -104,7 +104,7 @@ def test_install_volta_macos_arm64() -> None:
     ) as mock_download, patch(
         "devenv.lib.volta.archive.unpack"
     ) as mock_unpack:
-        install_volta("/path/to/unpack")
+        _install("/path/to/unpack")
         mock_system.assert_called_once()
         mock_machine.assert_called_once()
         mock_download.assert_called_once_with(
@@ -122,7 +122,7 @@ def test_install_volta_macos_arm64() -> None:
 def test_install_volta_unexpected_platform() -> None:
     with patch("platform.system", return_value="Unexpected"):
         with pytest.raises(UnexpectedPlatformError):
-            install_volta("/path/to/unpack")
+            _install("/path/to/unpack")
 
 
 def test_populate_volta_home_with_shims() -> None:


### PR DESCRIPTION
Instead of writing symlinks, we need shims that set VOLTA_HOME, forcing these repo-local bins to use the repo-local volta home for full containment. Otherwise, the default is to use ~/.volta.

This should be the last piece for full containment of repo-local bins (with the exception of ~/.lima which i'm willing to let slide).