### PR TITLE
fix: regression in pythons root

### DIFF
--- a/devenv/pythons.py
+++ b/devenv/pythons.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import os
 
-from devenv.constants import home
+from devenv.constants import root
 from devenv.lib import archive
 
 
 def get(python_version: str, url: str, sha256: str) -> str:
-    unpack_into = f"{home}/pythons/{python_version}"
+    unpack_into = f"{root}/pythons/{python_version}"
 
     if os.path.exists(f"{unpack_into}/python/bin/python3"):
         return f"{unpack_into}/python/bin/python3"

--- a/tests/test_pythons.py
+++ b/tests/test_pythons.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from devenv import pythons
+from devenv.constants import root
+
+
+def test_get() -> None:
+    with patch("devenv.lib.archive.download"), patch(
+        "devenv.lib.archive.unpack"
+    ), patch("os.path.exists", side_effect=[False, True]):
+        path = pythons.get("3.12.0", "foo", "bar")
+        assert path == f"{root}/pythons/3.12.0/python3"

--- a/tests/test_pythons.py
+++ b/tests/test_pythons.py
@@ -11,4 +11,4 @@ def test_get() -> None:
         "devenv.lib.archive.unpack"
     ), patch("os.path.exists", side_effect=[False, True]):
         path = pythons.get("3.12.0", "foo", "bar")
-        assert path == f"{root}/pythons/3.12.0/python3"
+        assert path == f"{root}/pythons/3.12.0/python/bin/python3"


### PR DESCRIPTION
just noticed an unfortunate regression in 3b27f121788bcdbb1a4528061a588fc78da7bd63 where i misinlined pythons_root to {home}/pythons and not {root}/pythons, lol

could have easily been avoided with a simple unittest which i've added