### PR TITLE
remove blobless clones

### DIFF
--- a/devenv/fetch.py
+++ b/devenv/fetch.py
@@ -108,17 +108,7 @@ def fetch(
         )
     )
 
-    proc.run(
-        (
-            "git",
-            "-C",
-            coderoot,
-            "clone",
-            "--filter=blob:none",
-            *additional_args,
-        ),
-        exit=True,
-    )
+    proc.run(("git", "-C", coderoot, "clone", *additional_args), exit=True)
 
     if sync:
         proc.run((sys.executable, "-P", "-m", "devenv", "sync"), cwd=codepath)


### PR DESCRIPTION
this may speed up initial clone, but it makes working with the repository history terribly inefficient and breaks basic git operations
