### PR TITLE
Use system python for venv on CI

### DIFF
--- a/devenv/pythons.py
+++ b/devenv/pythons.py
@@ -1,9 +1,38 @@
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 
+from devenv.constants import CI
 from devenv.constants import root
 from devenv.lib import archive
+
+
+def _check_version(exe: str, version: str) -> bool:
+    """Returns true if the executable at the given path is a python interpreter
+    with a semver-compatible version."""
+
+    try:
+        line = (
+            subprocess.check_output([exe, "--version"], text=True)
+            .strip()
+            .lower()
+        )
+    except subprocess.CalledProcessError:
+        return False
+
+    if not line.startswith("python "):
+        return False
+
+    actual = line[7:].split(".")
+    expected = version.split(".")
+
+    return (
+        len(actual) > 2
+        and actual[:2] == expected[:2]
+        and actual[2] >= expected[2]
+    )
 
 
 def get(python_version: str, url: str, sha256: str) -> str:
@@ -11,6 +40,11 @@ def get(python_version: str, url: str, sha256: str) -> str:
 
     if os.path.exists(f"{unpack_into}/python/bin/python3"):
         return f"{unpack_into}/python/bin/python3"
+
+    if CI:
+        system_py = shutil.which("python3")
+        if system_py is not None and _check_version(system_py, python_version):
+            return system_py
 
     archive_file = archive.download(url, sha256)
     archive.unpack(archive_file, unpack_into)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,4 @@ import pytest
 def pytest_configure(config: pytest.Config) -> None:
     os.environ["CI"] = "1"
     os.environ["SHELL"] = "/bin/bash"
+    os.environ["SENTRY_FORCE_PY"] = "1"

--- a/tests/test_pythons.py
+++ b/tests/test_pythons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
 
 from devenv import pythons
@@ -7,8 +8,19 @@ from devenv.constants import root
 
 
 def test_get() -> None:
-    with patch("devenv.lib.archive.download"), patch(
-        "devenv.lib.archive.unpack"
-    ), patch("os.path.exists", side_effect=[False, True]):
+    with (
+        patch("devenv.lib.archive.download"),
+        patch("devenv.lib.archive.unpack"),
+        patch("os.path.exists", side_effect=[False, True]),
+    ):
         path = pythons.get("3.12.0", "foo", "bar")
         assert path == f"{root}/pythons/3.12.0/python/bin/python3"
+
+
+def test_get_system() -> None:
+    v = sys.version_info
+    python_version = f"{v.major}.{v.minor}.{max(v.micro - 1, 0)}"
+
+    with patch("devenv.pythons.FORCE_PY", False):
+        path = pythons.get(python_version, "foo", "bar")
+        assert path == sys.executable


### PR DESCRIPTION
Devenv could be useful to setup the venv in CI, though at least in GHA `actions/setup-python` is much faster than a manual download of the matching python version. In CI, we usually take greater care for selecting the right python version already, so devenv could use that when it matches the expected version.

Downside of the current approach is that it silently falls back to downloading a new version if the system provided one doesn't match, which can regress CI times. That should be pretty visible in PRs, though. 