### PR TITLE
devenv: small things

### DIFF
--- a/devenv/constants.py
+++ b/devenv/constants.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import platform
 import pwd
 import typing
+
+version = importlib.metadata.version("sentry_devenv")
 
 CI = os.getenv("CI")
 SYSTEM = platform.system().lower()

--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -58,6 +58,8 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
     if (
         shutil.which("gcloud", path=binroot) == f"{binroot}/gcloud"
         and shutil.which("gsutil", path=binroot) == f"{binroot}/gsutil"
+        and shutil.which("gke-gcloud-auth-plugin", path=binroot)
+        == f"{binroot}/gke-gcloud-auth-plugin"
     ):
         with open(f"{binroot}/google-cloud-sdk/VERSION", "r") as f:
             installed_version = f.read().strip()
@@ -78,6 +80,11 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
             "--verbosity=error",
             "gke-gcloud-auth-plugin",
         )
+    )
+
+    fs.ensure_symlink(
+        f"{binroot}/google-cloud-sdk/bin/gke-gcloud-auth-plugin",
+        f"{binroot}/gke-gcloud-auth-plugin",
     )
 
     stdout = proc.run((f"{binroot}/gcloud", "--version"), stdout=True)

--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -131,3 +131,10 @@ def ensure(venv: str, python_version: str, url: str, sha256: str) -> None:
         (pythons.get(python_version, url, sha256), "-m", "venv", venv),
         exit=True,
     )
+
+    with open(f"{venv}/.gitignore", "w") as f:
+        f.write(
+            """*
+# automatically written by devenv
+"""
+        )

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -10,6 +10,7 @@ from devenv import fetch
 from devenv import pin_gha
 from devenv import sync
 from devenv.constants import home
+from devenv.constants import user
 from devenv.constants import version
 from devenv.lib.config import read_config
 from devenv.lib.context import Context
@@ -84,6 +85,9 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
 
 
 def main() -> ExitCode:
+    if user == "root":
+        raise SystemExit("You shouldn't be running devenv as root.")
+
     import sys
     import sentry_sdk
 

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -21,10 +21,6 @@ from devenv.lib.repository import Repository
 
 
 def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
-    if len(argv) > 1 and argv[1] in ("version", "--version"):
-        print(f"devenv {version}")
-        return 0
-
     # determine current repo, if applicable
     fake_reporoot = os.getenv("CI_DEVENV_INTEGRATION_FAKE_REPOROOT")
     if fake_reporoot:
@@ -54,6 +50,7 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
     # TODO: Search for modules in work repo
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--version", action="version", version=version)
     subparser = parser.add_subparsers(
         title=argparse.SUPPRESS,
         metavar="command",

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -64,6 +64,10 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
         # Argparse stuff
         subparser.add_parser(info.command, help=info.help)
 
+    if len(argv) == 1:
+        parser.print_help()
+        return 0
+
     args, remainder = parser.parse_known_args(argv[1:])
 
     # context for subcommands

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -10,6 +10,7 @@ from devenv import fetch
 from devenv import pin_gha
 from devenv import sync
 from devenv.constants import home
+from devenv.constants import version
 from devenv.lib.config import read_config
 from devenv.lib.context import Context
 from devenv.lib.fs import gitroot
@@ -19,6 +20,10 @@ from devenv.lib.repository import Repository
 
 
 def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
+    if len(argv) > 1 and argv[1] in ("version", "--version"):
+        print(f"devenv {version}")
+        return 0
+
     # determine current repo, if applicable
     fake_reporoot = os.getenv("CI_DEVENV_INTEGRATION_FAKE_REPOROOT")
     if fake_reporoot:

--- a/tests/lib/test_venv.py
+++ b/tests/lib/test_venv.py
@@ -37,13 +37,14 @@ linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504c
 def test_get_ensure(tmp_path: pathlib.Path) -> None:
     repo = Repository(f"{tmp_path}/ops")
 
-    os.makedirs(f"{repo.config_path}")
+    os.makedirs(repo.config_path)
     with open(f"{repo.config_path}/config.ini", "w") as f:
         f.write(mock_config)
 
     venv_dir, python_version, requirements, editable_paths, bins = venv.get(
         repo.path, "sentry-kube"
     )
+    os.makedirs(venv_dir)
 
     assert (venv_dir, python_version, requirements, editable_paths, bins) == (
         f"{repo.path}/.venv-sentry-kube",
@@ -57,7 +58,7 @@ def test_get_ensure(tmp_path: pathlib.Path) -> None:
 
     with patch("devenv.lib.venv.proc.run") as mock_run, patch(
         "devenv.lib.venv.pythons.get", return_value="python"
-    ) as mock_pythons_get:
+    ) as mock_pythons_get, patch("shutil.rmtree"):
         venv.ensure(venv_dir, python_version, url, sha256)
         assert mock_pythons_get.mock_calls == [
             call(python_version, url, sha256)
@@ -65,9 +66,9 @@ def test_get_ensure(tmp_path: pathlib.Path) -> None:
         assert mock_run.mock_calls == [
             call(("python", "-m", "venv", venv_dir), exit=True)
         ]
+        assert os.path.isfile(f"{venv_dir}/.gitignore")
 
     # fake venv
-    os.makedirs(venv_dir)
     with open(f"{venv_dir}/pyvenv.cfg", "w") as f:
         f.write(f"version = {python_version}\n")
 


### PR DESCRIPTION
it's the small things in life...

Wanted to get these things in before I cut a new release for https://github.com/getsentry/sentry/pull/72870.

- adds `version/--version`, and `devenv` by itself now prints full usage (instead of pretty much nothing)
- fixes a little bug with gke-gcloud-auth-plugin not on devenv's path
- devenv venvs gitignore themselves!