### PR TITLE
feat: colima robust start and convenience commands

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,24 +18,24 @@ env:
   DEBUG: "1"
 
 jobs:
-   bootstrap:
-     runs-on: ubuntu-22.04
-     timeout-minutes: 60
-     env:
-       SENTRY_BRANCH: master
-       SNTY_DEVENV_BRANCH:
-         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
-     steps:
-       - uses: actions/checkout@v3
-       - name: install
-         run: |
-           set -u
-           : should be able to be run from anywhere:
-           repo=$PWD
-           mv install-devenv.sh /tmp
-           cd /tmp
-           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-       - name: bootstrap sentry
+  bootstrap:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      SENTRY_BRANCH: master
+      SNTY_DEVENV_BRANCH:
+        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
+    steps:
+      - uses: actions/checkout@v3
+      - name: install
+        run: |
+          set -u
+          : should be able to be run from anywhere:
+          repo=$PWD
+          mv install-devenv.sh /tmp
+          cd /tmp
+          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
+      - name: bootstrap sentry
         run: ./ci/devenv-bootstrap.sh
 
   # macos-14 doesn't support the virtualization needed for colima... yet

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,35 +18,35 @@ env:
   DEBUG: "1"
 
 jobs:
-  bootstrap:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-    env:
-      SENTRY_BRANCH: master
-      SNTY_DEVENV_BRANCH:
-        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
-    steps:
-      - uses: actions/checkout@v3
-      - name: install
-        run: |
-          set -u
-          : should be able to be run from anywhere:
-          repo=$PWD
-          mv install-devenv.sh /tmp
-          cd /tmp
-          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-      - name: bootstrap sentry
-        run: ./ci/devenv-bootstrap.sh
+#  bootstrap:
+#    runs-on: ubuntu-22.04
+#    timeout-minutes: 60
+#    env:
+#      SENTRY_BRANCH: master
+#      SNTY_DEVENV_BRANCH:
+#        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: install
+#        run: |
+#          set -u
+#          : should be able to be run from anywhere:
+#          repo=$PWD
+#          mv install-devenv.sh /tmp
+#          cd /tmp
+#          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
+#      - name: bootstrap sentry
+#        run: ./ci/devenv-bootstrap.sh
 
   # macos-14 doesn't support the virtualization needed for colima... yet
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: master
+      SENTRY_BRANCH: feat-robust-start-colima
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,35 +18,35 @@ env:
   DEBUG: "1"
 
 jobs:
-#  bootstrap:
-#    runs-on: ubuntu-22.04
-#    timeout-minutes: 60
-#    env:
-#      SENTRY_BRANCH: master
-#      SNTY_DEVENV_BRANCH:
-#        "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: install
-#        run: |
-#          set -u
-#          : should be able to be run from anywhere:
-#          repo=$PWD
-#          mv install-devenv.sh /tmp
-#          cd /tmp
-#          ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
-#      - name: bootstrap sentry
-#        run: ./ci/devenv-bootstrap.sh
+   bootstrap:
+     runs-on: ubuntu-22.04
+     timeout-minutes: 60
+     env:
+       SENTRY_BRANCH: master
+       SNTY_DEVENV_BRANCH:
+         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
+     steps:
+       - uses: actions/checkout@v3
+       - name: install
+         run: |
+           set -u
+           : should be able to be run from anywhere:
+           repo=$PWD
+           mv install-devenv.sh /tmp
+           cd /tmp
+           ./install-devenv.sh  < $repo/ci/install-devenv-checks.sh
+       - name: bootstrap sentry
+        run: ./ci/devenv-bootstrap.sh
 
   # macos-14 doesn't support the virtualization needed for colima... yet
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:
-      SENTRY_BRANCH: feat-robust-start-colima
+      SENTRY_BRANCH: master
       SNTY_DEVENV_BRANCH:
         "${{ github.event.pull_request && github.head_ref || github.ref_name }}"
     steps:

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -17,7 +17,7 @@ EOF
 cd "$HOME"
 # note: colima will be used and is necessary for a docker runtime on
 #       macos GitHub runners
-export DEVENV_FETCH_BRANCH=devenv-sync-setup-git
+export DEVENV_FETCH_BRANCH=feat-robust-start-colima
 devenv bootstrap
 devenv fetch sentry
 

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -17,7 +17,7 @@ EOF
 cd "$HOME"
 # note: colima will be used and is necessary for a docker runtime on
 #       macos GitHub runners
-export DEVENV_FETCH_BRANCH=feat-robust-start-colima
+export DEVENV_FETCH_BRANCH=master
 devenv bootstrap
 devenv fetch sentry
 

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -24,6 +24,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 
     if args.command == "start":
         status = colima.start(repo_path)
+        print("cli start rc", status)
         if status == colima.ColimaStatus.UNHEALTHY:
             # https://github.com/abiosoft/colima/issues/949
             print("colima seems unhealthy, we'll try restarting once")

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -16,7 +16,9 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
     repo_path = context["repo"].path  # type: ignore
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("start",))
+    parser.add_argument(
+        "command", choices=("start", "restart", "check", "stop")
+    )
 
     args = parser.parse_args(argv)
 

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+from collections.abc import Sequence
+
+from devenv.constants import home
+from devenv.lib import proc
+from devenv.lib.context import Context
+from devenv.lib.modules import DevModuleInfo
+from devenv.lib.modules import require_repo
+
+
+def start(reporoot: str) -> None:
+    if not os.getenv("CI"):
+        macos_version = platform.mac_ver()[0]
+        macos_major_version = int(macos_version.split(".")[0])
+        if macos_major_version < 14:
+            raise SystemExit(
+                f"macos >= 14 is required to use colima, found {macos_version}"
+            )
+
+    if not shutil.which("docker"):
+        raise SystemExit(
+            "docker executable not found, you might want to run devenv sync"
+        )
+
+    colima = f"{reporoot}/.devenv/bin/colima"
+    if not os.path.isfile(colima):
+        raise SystemExit(
+            f"colima not found at {colima}, you might want to run devenv sync"
+        )
+
+    cpus = os.cpu_count()
+    if cpus is None:
+        raise SystemExit("failed to determine cpu count")
+
+    # SC_PAGE_SIZE is POSIX 2008
+    # SC_PHYS_PAGES is a linux addition but also supported by more recent MacOS versions
+    SC_PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
+    SC_PHYS_PAGES = os.sysconf("SC_PHYS_PAGES")
+    if SC_PAGE_SIZE == -1 or SC_PHYS_PAGES == -1:
+        raise SystemExit("failed to determine memsize_bytes")
+    memsize_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+
+    args = ["--cpu", f"{cpus//2}", "--memory", f"{memsize_bytes//(2*1024**3)}"]
+    if platform.machine() == "arm64":
+        args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
+
+    proc.run(
+        (
+            # we share the "default" machine across repositories
+            colima,
+            "start",
+            "--verbose",
+            # ideally we keep ~ ro and reporoot rw, but currently the "default" vm
+            # is shared across repositories, so for ease of use we'll let home rw
+            f"--mount=/var/folders:w,/private/tmp/colima:w,{home}:w",
+            *args,
+        ),
+        pathprepend=f"{reporoot}/.devenv/bin",
+    )
+
+    proc.run(("docker", "context", "use", "colima"))
+
+
+@require_repo
+def main(context: Context, argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args(argv)
+
+    repo = context["repo"]
+    # repo.path
+    return 0
+
+
+module_info = DevModuleInfo(
+    action=main,
+    name=__name__,
+    command="colima",
+    help="Colima convenience commands.",
+)

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -26,10 +26,11 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
         case "start":
             status = colima.start(repo_path)
             if status == colima.ColimaStatus.UNHEALTHY:
-                # TODO: retry at least once once
-                # we have better unhealthy check
-                # for https://github.com/abiosoft/colima/issues/949
-                pass
+                # https://github.com/abiosoft/colima/issues/949
+                print("colima seems unhealthy, we'll try restarting once")
+                status = colima.restart(repo_path)
+                if status != colima.ColimaStatus.UP:
+                    return 1
             if status != colima.ColimaStatus.UP:
                 return 1
         case "restart":

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -22,29 +22,28 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    match args.command:
-        case "start":
-            status = colima.start(repo_path)
-            if status == colima.ColimaStatus.UNHEALTHY:
-                # https://github.com/abiosoft/colima/issues/949
-                print("colima seems unhealthy, we'll try restarting once")
-                status = colima.restart(repo_path)
-                if status != colima.ColimaStatus.UP:
-                    return 1
-            if status != colima.ColimaStatus.UP:
-                return 1
-        case "restart":
+    if args.command == "start":
+        status = colima.start(repo_path)
+        if status == colima.ColimaStatus.UNHEALTHY:
+            # https://github.com/abiosoft/colima/issues/949
+            print("colima seems unhealthy, we'll try restarting once")
             status = colima.restart(repo_path)
             if status != colima.ColimaStatus.UP:
                 return 1
-        case "check":
-            status = colima.check(repo_path)
-            if status != colima.ColimaStatus.UP:
-                return 1
-        case "stop":
-            status = colima.stop(repo_path)
-            if status != colima.ColimaStatus.DOWN:
-                return 1
+        if status != colima.ColimaStatus.UP:
+            return 1
+    elif args.command == "restart":
+        status = colima.restart(repo_path)
+        if status != colima.ColimaStatus.UP:
+            return 1
+    elif args.command == "check":
+        status = colima.check(repo_path)
+        if status != colima.ColimaStatus.UP:
+            return 1
+    elif args.command == "stop":
+        status = colima.stop(repo_path)
+        if status != colima.ColimaStatus.DOWN:
+            return 1
 
     return 0
 

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -8,71 +8,27 @@ from collections.abc import Sequence
 
 from devenv.constants import home
 from devenv.lib import proc
+from devenv.lib import colima
 from devenv.lib.context import Context
 from devenv.lib.modules import DevModuleInfo
 from devenv.lib.modules import require_repo
 
-
-def start(reporoot: str) -> None:
-    if not os.getenv("CI"):
-        macos_version = platform.mac_ver()[0]
-        macos_major_version = int(macos_version.split(".")[0])
-        if macos_major_version < 14:
-            raise SystemExit(
-                f"macos >= 14 is required to use colima, found {macos_version}"
-            )
-
-    if not shutil.which("docker"):
-        raise SystemExit(
-            "docker executable not found, you might want to run devenv sync"
-        )
-
-    colima = f"{reporoot}/.devenv/bin/colima"
-    if not os.path.isfile(colima):
-        raise SystemExit(
-            f"colima not found at {colima}, you might want to run devenv sync"
-        )
-
-    cpus = os.cpu_count()
-    if cpus is None:
-        raise SystemExit("failed to determine cpu count")
-
-    # SC_PAGE_SIZE is POSIX 2008
-    # SC_PHYS_PAGES is a linux addition but also supported by more recent MacOS versions
-    SC_PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
-    SC_PHYS_PAGES = os.sysconf("SC_PHYS_PAGES")
-    if SC_PAGE_SIZE == -1 or SC_PHYS_PAGES == -1:
-        raise SystemExit("failed to determine memsize_bytes")
-    memsize_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-
-    args = ["--cpu", f"{cpus//2}", "--memory", f"{memsize_bytes//(2*1024**3)}"]
-    if platform.machine() == "arm64":
-        args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
-
-    proc.run(
-        (
-            # we share the "default" machine across repositories
-            colima,
-            "start",
-            "--verbose",
-            # ideally we keep ~ ro and reporoot rw, but currently the "default" vm
-            # is shared across repositories, so for ease of use we'll let home rw
-            f"--mount=/var/folders:w,/private/tmp/colima:w,{home}:w",
-            *args,
-        ),
-        pathprepend=f"{reporoot}/.devenv/bin",
-    )
-
-    proc.run(("docker", "context", "use", "colima"))
+module_help = "Colima convenience commands."
 
 
 @require_repo
 def main(context: Context, argv: Sequence[str] | None = None) -> int:
+    repo_path = context["repo"].path
+
     parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("start",))
+
     args = parser.parse_args(argv)
 
-    repo = context["repo"]
-    # repo.path
+    match args.command:
+        case "start":
+            colima.start(repo_path)
+
     return 0
 
 
@@ -80,5 +36,5 @@ module_info = DevModuleInfo(
     action=main,
     name=__name__,
     command="colima",
-    help="Colima convenience commands.",
+    help=module_help,
 )

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -23,9 +23,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "start":
-        print("cli starting")
         status = colima.start(repo_path)
-        print("cli status", status)
         if status == colima.ColimaStatus.UNHEALTHY:
             # https://github.com/abiosoft/colima/issues/949
             print("colima seems unhealthy, we'll try restarting once")

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -23,8 +23,9 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "start":
+        print("cli starting")
         status = colima.start(repo_path)
-        print("cli start rc", status)
+        print("cli status", status)
         if status == colima.ColimaStatus.UNHEALTHY:
             # https://github.com/abiosoft/colima/issues/949
             print("colima seems unhealthy, we'll try restarting once")

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -100,7 +100,9 @@ def check(reporoot: str) -> ColimaStatus:
         return ColimaStatus.UNHEALTHY
 
     # https://github.com/abiosoft/colima/issues/949
-    if not docker.check_docker_to_host_connectivity():
+    healthy = docker.check_docker_to_host_connectivity()
+    print("healthy", healthy)
+    if not healthy:
         return ColimaStatus.UNHEALTHY
 
     return ColimaStatus.UP
@@ -108,7 +110,6 @@ def check(reporoot: str) -> ColimaStatus:
 
 def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     status = check(reporoot)
-    print("lib start rc", status)
 
     if status == ColimaStatus.UP:
         if not restart:
@@ -152,6 +153,7 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
 
     proc.run(("docker", "context", "use", "colima"))
 
+    print("post start check begins")
     status = check(reporoot)
     return status
 

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -92,7 +92,7 @@ def check(reporoot: str) -> ColimaStatus:
     # if colima's up, we should be able to communicate with that docker socket
     # at the most basic level
     try:
-        proc.run((docker, "--context=colima", "version"))
+        proc.run((docker, "--context=colima", "version"), stdout=True)
         # TODO: need more rigorous healthchecks for unhealthiness
         # for https://github.com/abiosoft/colima/issues/949
         return ColimaStatus.UP
@@ -155,6 +155,6 @@ def restart(reporoot: str) -> ColimaStatus:
 
 
 def stop(reporoot: str) -> ColimaStatus:
-    proc.run(("colima", "stop"))
+    proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
     status = check(reporoot)
     return status

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -109,16 +109,15 @@ def check(reporoot: str) -> ColimaStatus:
 def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     status = check(reporoot)
 
-    match status:
-        case ColimaStatus.UP:
-            if not restart:
-                return ColimaStatus.UP
-            proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
-        case ColimaStatus.DOWN:
-            pass
-        case ColimaStatus.UNHEALTHY:
-            print("colima seems to be unhealthy, stopping it")
-            proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+    if status == ColimaStatus.UP:
+        if not restart:
+            return ColimaStatus.UP
+        proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+    elif status == ColimaStatus.DOWN:
+        pass
+    elif status == ColimaStatus.UNHEALTHY:
+        print("colima seems to be unhealthy, stopping it")
+        proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
 
     cpus = os.cpu_count()
     if cpus is None:

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -107,11 +107,12 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
         case ColimaStatus.UP:
             if not restart:
                 return ColimaStatus.UP
+            proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
         case ColimaStatus.DOWN:
             pass
         case ColimaStatus.UNHEALTHY:
             print("colima seems to be unhealthy, stopping it")
-            proc.run(("colima", "stop"))
+            proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
 
     cpus = os.cpu_count()
     if cpus is None:

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -101,7 +101,6 @@ def check(reporoot: str) -> ColimaStatus:
 
     # https://github.com/abiosoft/colima/issues/949
     healthy = docker.check_docker_to_host_connectivity()
-    print("healthy", healthy)
     if not healthy:
         return ColimaStatus.UNHEALTHY
 
@@ -153,7 +152,6 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
 
     proc.run(("docker", "context", "use", "colima"))
 
-    print("post start check begins")
     status = check(reporoot)
     return status
 

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -108,6 +108,7 @@ def check(reporoot: str) -> ColimaStatus:
 
 def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     status = check(reporoot)
+    print("lib start rc", status)
 
     if status == ColimaStatus.UP:
         if not restart:

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+from threading import Thread
+
+
+def _accept_and_close(sock: socket.socket) -> None:
+    sock.listen()
+    conn, addr = sock.accept()
+    conn.close()
+
+
+def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+
+    listener = Thread(target=_accept_and_close, args=(sock,))
+    listener.start()
+
+    rc = subprocess.call(
+        (
+            "docker",
+            "run",
+            "--rm",
+            "--add-host=host.docker.internal:host-gateway",
+            "busybox:1.36.1-musl",
+            "/bin/sh",
+            "-c",
+            f"/bin/echo hi | /bin/nc -w {timeout} host.docker.internal 6968",
+        )
+    )
+
+    if rc != 0:
+        # easiest way to terminate the socket server
+        # (so the thread doesn't indefinitely hang)
+        s = socket.socket()
+        s.connect(("127.0.0.1", port))
+        s.send(b"hi")
+        s.close()
+        return False
+
+    listener.join()
+    return True

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -28,17 +28,16 @@ def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
             "busybox:1.36.1-musl",
             "/bin/sh",
             "-c",
-            f"/bin/echo hi | /bin/nc -w {timeout} host.docker.internal 6968",
+            f"/bin/echo hi | /bin/nc -w {timeout} host.docker.internal {port}",
         )
     )
 
     if rc != 0:
         # easiest way to terminate the socket server
         # (so the thread doesn't indefinitely hang)
-        s = socket.socket()
-        s.connect(("127.0.0.1", port))
-        s.send(b"hi")
-        s.close()
+        with socket.socket() as s:
+            s.connect(("127.0.0.1", port))
+            s.send(b"hi")
         return False
 
     listener.join()

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -13,7 +13,7 @@ def _accept_and_close(sock: socket.socket) -> None:
 
 def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
     sock = socket.socket()
-    sock.bind(("", 0))
+    sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
 
     listener = Thread(target=_accept_and_close, args=(sock,))

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -8,7 +8,6 @@ from threading import Thread
 def _accept_and_close(sock: socket.socket) -> None:
     sock.listen()
     conn, addr = sock.accept()
-    print(conn.recv(8))
     conn.close()
 
 
@@ -41,9 +40,7 @@ def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
             s.send(b"die")
 
         listener.join()
-        print("listener joined")
         return False
 
-    print("listener joined")
     listener.join()
     return True

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -8,6 +8,7 @@ from threading import Thread
 def _accept_and_close(sock: socket.socket) -> None:
     sock.listen()
     conn, addr = sock.accept()
+    print(conn.recv(8))
     conn.close()
 
 
@@ -37,7 +38,7 @@ def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
         # (so the thread doesn't indefinitely hang)
         with socket.socket() as s:
             s.connect(("127.0.0.1", port))
-            s.send(b"hi")
+            s.send(b"die")
         return False
 
     listener.join()

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -39,7 +39,11 @@ def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
         with socket.socket() as s:
             s.connect(("127.0.0.1", port))
             s.send(b"die")
+
+        listener.join()
+        print("listener joined")
         return False
 
+    print("listener joined")
     listener.join()
     return True

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -5,6 +5,7 @@ import os
 from collections.abc import Sequence
 
 from devenv import bootstrap
+from devenv import colima
 from devenv import doctor
 from devenv import fetch
 from devenv import pin_gha
@@ -43,7 +44,7 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
 
     modinfo_list: Sequence[DevModuleInfo] = [
         module.module_info
-        for module in [bootstrap, fetch, doctor, pin_gha, sync]
+        for module in [bootstrap, fetch, colima, doctor, pin_gha, sync]
         if hasattr(module, "module_info")
     ]
 


### PR DESCRIPTION
Sentry will use this like this: https://github.com/getsentry/sentry/pull/74975

This improves on sentry's `scripts/start-colima.py` and makes starting colima more robust in that we check for host.docker.internal communication to actually work.

Also this lets people manage colima more easily now that it's exposed as cli and can be used in scripting too.

Currently there's a known issue where if you have a fresh colima vm, it doesn't work the first time and needs to be restarted - this affects new engineers, and those who had to `colima delete`. This issue becomes evident once you try and ingest events in devserver since relay relies on host.docker.internal.

<img width="736" alt="image" src="https://github.com/user-attachments/assets/b3163aa6-f7cc-4994-b404-b31a7d6b3975">
