### PR TITLE
feat: ensure rosetta before colima start

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -42,7 +42,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -11,6 +11,7 @@ from devenv.lib import brew
 from devenv.lib import direnv
 from devenv.lib import github
 from devenv.lib import proc
+from devenv.lib import rosetta
 from devenv.lib.config import Config
 from devenv.lib.config import initialize_config
 from devenv.lib.context import Context
@@ -50,6 +51,10 @@ def main(context: Context, argv: Sequence[str] | None = None) -> ExitCode:
             _ = proc.run(("xcrun", "-f", "git"), stdout=True)
         except RuntimeError:
             return "Failed to find git. Run xcode-select --install, then re-run bootstrap when done."
+
+    # even though this is called before colima starts,
+    # better to try and potentially (although unlikely) fail earlier rather than later
+    rosetta.ensure()
 
     github.add_to_known_hosts()
 

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -13,6 +13,7 @@ from devenv.lib import archive
 from devenv.lib import docker
 from devenv.lib import fs
 from devenv.lib import proc
+from devenv.lib import rosetta
 
 
 ColimaStatus = Enum("ColimaStatus", ("UP", "DOWN", "UNHEALTHY"))
@@ -119,6 +120,10 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     elif status == ColimaStatus.UNHEALTHY:
         print("colima seems to be unhealthy, stopping it")
         proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+
+    # colima start will only WARN if rosetta is unavailable and keep going without it,
+    # so we need to ensure it's installed and running ourselves
+    rosetta.ensure()
 
     cpus = os.cpu_count()
     if cpus is None:

--- a/devenv/lib/rosetta.py
+++ b/devenv/lib/rosetta.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+from devenv.constants import DARWIN
+from devenv.constants import MACHINE
+from devenv.lib import proc
+
+
+def ensure() -> None:
+    if not (DARWIN and (MACHINE == "arm64")):
+        return
+
+    # this file doesn't exist if rosetta 2 isn't installed
+    if not os.path.exists("/usr/libexec/rosetta/oahd"):
+        proc.run(
+            ("softwareupdate", "--install-rosetta", "--agree-to-license"),
+            exit=True,
+        )
+
+    # if rosetta 2 is installed and not running, the fastest way to start
+    # /usr/libexec/rosetta/oahd is to request an emulated program with /usr/bin/arch
+    stdout = proc.run(
+        ("/usr/bin/arch", "-x86_64", "/bin/sh", "-c", "/usr/bin/uname -m"),
+        stdout=True,
+    )
+
+    # we can also verify it's actually working, compared to pgrep -f /usr/libexec/rosetta/oahd
+    # this is also more precise than merely checking sysctl -n sysctl.proc_translated == 1
+    if stdout.strip() != "x86_64":
+        raise SystemExit(f"Rosetta 2 not working as expected.\ndebug: {stdout}")


### PR DESCRIPTION
on a new mac arm dev machine, if rosetta isn't installed, colima start --vz-rosetta will just warn about it and blissfully proceed without rosetta

it's pretty cheap to ensure rosetta's installed + running so let's just unconditionally do this before starting colima