### PR TITLE
feat: devenv update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ Download [this](https://raw.githubusercontent.com/getsentry/devenv/main/install-
 bash install-devenv.sh
 ```
 
+This "global" devenv is installed to `~/.local/share/sentry-devenv`.
+
+To update this installation, run `devenv update`.
+
+
 ## user guide
 
 `devenv bootstrap`
 
-This is intended for initial setup. 
+This is intended for initial setup.
 
 
 `devenv fetch [repository name]`
@@ -48,7 +53,8 @@ When you're inside a repository, this completely removes the dev environment.
 
 ## technical overview
 
-devenv itself lives in `~/.local/share/sentry-devenv`. Inside:
+devenv itself lives in `~/.local/share/sentry-devenv`.
+This is the "global" devenv. Inside:
 - `bin` contains devenv itself and `direnv`
   - this is the only PATH entry needed for devenv
 - a private python and virtualenv used exclusively by `devenv`

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -14,6 +14,9 @@ EOF
 
 : PATH: "$PATH"
 
+# doesn't functionally do anything, just exercises
+devenv update
+
 cd "$HOME"
 # note: colima will be used and is necessary for a docker runtime on
 #       macos GitHub runners

--- a/devenv/lib/proc.py
+++ b/devenv/lib/proc.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
-from subprocess import CalledProcessError
-from subprocess import PIPE
-from subprocess import run as subprocess_run
 from typing import Literal
 from typing import overload
 
@@ -68,9 +66,11 @@ def run(
     exit: bool = False,
     env: dict[str, str] | None = None,
     cwd: Path | str | None = None,
+    # poorly named, should've been like capture_combined_output
     stdout: bool = False,
 ) -> str | None:
-    _stdout = PIPE if stdout else None
+    _stdout = subprocess.PIPE if stdout else None
+    _stderr = subprocess.STDOUT if stdout else None
     del stdout
 
     if env is None:
@@ -83,18 +83,20 @@ def run(
     if constants.DEBUG:
         xtrace(cmd)
     try:
-        proc = subprocess_run(cmd, check=True, stdout=_stdout, cwd=cwd, env=env)
+        proc = subprocess.run(
+            cmd, check=True, stdout=_stdout, stderr=_stderr, cwd=cwd, env=env
+        )
     except FileNotFoundError as e:
         # This is reachable if the command isn't found.
         if exit:
             raise SystemExit(f"{e}") from None
         else:
             raise RuntimeError(f"{e}") from None
-    except CalledProcessError as e:
+    except subprocess.CalledProcessError as e:
         detail = f"Command `{quote(e.cmd)}` failed! (code {e.returncode})"
         if _stdout:
             detail += f"""
-stdout:
+combined out:
 {"" if e.stdout is None else e.stdout.decode()}
 """
         if exit:

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -10,6 +10,7 @@ from devenv import doctor
 from devenv import fetch
 from devenv import pin_gha
 from devenv import sync
+from devenv import update
 from devenv.constants import home
 from devenv.constants import user
 from devenv.constants import version
@@ -44,7 +45,7 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
 
     modinfo_list: Sequence[DevModuleInfo] = [
         module.module_info
-        for module in [bootstrap, fetch, colima, doctor, pin_gha, sync]
+        for module in [bootstrap, fetch, colima, doctor, pin_gha, sync, update]
         if hasattr(module, "module_info")
     ]
 

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from devenv import constants
+from devenv.lib import proc
+from devenv.lib.context import Context
+from devenv.lib.modules import DevModuleInfo
+
+module_help = "Updates global devenv."
+
+
+def main(context: Context, argv: Sequence[str] | None = None) -> int:
+    if not sys.executable.startswith(f"{constants.root}/venv/bin/python"):
+        raise SystemExit(
+            f"""
+update is only applicable to the global devenv.
+This one is using: {sys.executable}
+
+To update the global devenv, run `{constants.root}/bin/devenv update`.
+
+To update a repo-local devenv, run `devenv sync`.
+
+(It's the responsibility of devenv/sync.py and devenv/config.ini to
+maintain a virtualenv with a devenv version for that particular repository.)
+"""
+        )
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", type=str, nargs="?")
+
+    args = parser.parse_args(argv)
+
+    if args.version is None:
+        proc.run(
+            (
+                f"{constants.root}/venv/bin/pip",
+                "install",
+                "-U",
+                "sentry-devenv",
+            ),
+            env={
+                # better than cli flag (who knows if it'll break in the future)
+                "PIP_DISABLE_PIP_VERSION_CHECK": "1"
+            },
+        )
+    else:
+        proc.run(
+            (
+                f"{constants.root}/venv/bin/pip",
+                "install",
+                f"sentry-devenv=={args.version}",
+            ),
+            env={
+                # better than cli flag (who knows if it'll break in the future)
+                "PIP_DISABLE_PIP_VERSION_CHECK": "1"
+            },
+        )
+
+    return 0
+
+
+module_info = DevModuleInfo(
+    action=main, name=__name__, command="update", help=module_help
+)

--- a/tests/lib/test_proc.py
+++ b/tests/lib/test_proc.py
@@ -97,3 +97,21 @@ def test_run_command_failed_with_exit() -> None:
 
     with pytest.raises(SystemExit):
         run(cmd, exit=True)
+
+
+def test_run_command_failed_capture_combined_output() -> None:
+    cmd = ("sh", "-c", "echo foo && echo >&2 err && echo bar && false")
+
+    try:
+        run(cmd, stdout=True, exit=False)
+    except RuntimeError as e:
+        assert (
+            f"{e}"
+            == """Command `sh -c 'echo foo && echo >&2 err && echo bar && false'` failed! (code 1)
+combined out:
+foo
+err
+bar
+
+"""
+        )


### PR DESCRIPTION
This adds a `devenv update` command for updating the global devenv install which people have been requesting. Most users outside of sentry are using global devenv (also, not all repos will need a python venv so no repo-local devenv) and we should better support this use case by making updates easy.

Up until now I've been recommending downloading and rerunning `install-devenv.sh`, but I just realized this is better: `~/.local/share/sentry-devenv/venv/bin/pip install -U sentry-devenv`
