### PR TITLE
fix(node): ignore npm prefix if configured, ensuring we use our own

### DIFF
--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -94,10 +94,6 @@ fi
 export PATH="${HOME}/code/sentry/.devenv/bin:${HOME}/code/sentry/node_modules/.bin:${HOME}/.local/share/sentry-devenv/bin:${PATH}"
 export VIRTUAL_ENV="${HOME}/code/sentry/.venv"
 
-cat "${HOME}/code/sentry/.devenv/bin/node"
-ls -lah "${HOME}/code/sentry/.devenv/bin/node-env/bin"
-ls -lah "${HOME}/.local/lib/nodejs"
-
 expected="${HOME}/code/sentry/.devenv/bin/node"
 got=$(command -v node)
 if [[ "$got" != "$expected" ]]; then

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -18,8 +18,6 @@ cat <<EOF > "$HOME/.npmrc"
 prefix = ${HOME}/.local/lib/nodejs
 EOF
 
-cat "$HOME/.npmrc"
-
 : PATH: "$PATH"
 
 # doesn't functionally do anything, just exercises
@@ -97,7 +95,7 @@ export PATH="${HOME}/code/sentry/.devenv/bin:${HOME}/code/sentry/node_modules/.b
 export VIRTUAL_ENV="${HOME}/code/sentry/.venv"
 
 cat "${HOME}/code/sentry/.devenv/bin/node"
-ls -lah "${HOME}/.devenv/bin/node-env/bin"
+ls -lah "${HOME}/code/sentry/.devenv/bin/node-env/bin"
 ls -lah "${HOME}/.local/lib/nodejs"
 
 expected="${HOME}/code/sentry/.devenv/bin/node"

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -18,6 +18,8 @@ cat <<EOF > "$HOME/.npmrc"
 prefix = ${HOME}/.local/lib/nodejs
 EOF
 
+cat "$HOME/.npmrc"
+
 : PATH: "$PATH"
 
 # doesn't functionally do anything, just exercises
@@ -93,6 +95,10 @@ fi
 # so instead, just do here the essentials that sentry's .envrc does
 export PATH="${HOME}/code/sentry/.devenv/bin:${HOME}/code/sentry/node_modules/.bin:${HOME}/.local/share/sentry-devenv/bin:${PATH}"
 export VIRTUAL_ENV="${HOME}/code/sentry/.venv"
+
+cat "${HOME}/code/sentry/.devenv/bin/node"
+ls -lah "${HOME}/.devenv/bin/node-env/bin"
+ls -lah "${HOME}/.local/lib/nodejs"
 
 expected="${HOME}/code/sentry/.devenv/bin/node"
 got=$(command -v node)

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -13,6 +13,11 @@ name = "getsentry-mock"
 version = "0.0.0"
 EOF
 
+# devenv should ignore npm's prefix even if it's changed via config
+cat <<EOF > "$HOME/.npmrc"
+prefix = ${HOME}/.local/lib/nodejs
+EOF
+
 : PATH: "$PATH"
 
 # doesn't functionally do anything, just exercises

--- a/devenv/lib/node.py
+++ b/devenv/lib/node.py
@@ -81,14 +81,11 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
     uninstall(binroot)
     _install(url, sha256, binroot)
 
-    # NPM_CONFIG_PREFIX is needed to ensure npm install -g yarn
-    # puts yarn into our node-env.
-
     for shim in _shims:
         fs.write_script(
             f"{binroot}/{shim}",
             f"""#!/bin/sh
-exec /usr/bin/env PATH={binroot}/node-env/bin:"$PATH" NPM_CONFIG_PREFIX="{binroot}/node-env" {binroot}/node-env/bin/{shim} "$@"
+exec /usr/bin/env PATH={binroot}/node-env/bin:"$PATH" {binroot}/node-env/bin/{shim} "$@"
 """,
         )
 

--- a/devenv/lib/node.py
+++ b/devenv/lib/node.py
@@ -81,11 +81,14 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
     uninstall(binroot)
     _install(url, sha256, binroot)
 
+    # NPM_CONFIG_PREFIX is needed to ensure npm install -g yarn
+    # puts yarn into our node-env.
+
     for shim in _shims:
         fs.write_script(
             f"{binroot}/{shim}",
             f"""#!/bin/sh
-exec /usr/bin/env PATH={binroot}/node-env/bin:"$PATH" {binroot}/node-env/bin/{shim} "$@"
+exec /usr/bin/env PATH={binroot}/node-env/bin:"$PATH" NPM_CONFIG_PREFIX="{binroot}/node-env" {binroot}/node-env/bin/{shim} "$@"
 """,
         )
 


### PR DESCRIPTION
@evanpurkhiser was having trouble with devenv sync bc he had configured a different npm prefix, this ensures we explicitly use our own for `install -g`'s

```
› .devenv/bin/npm install -g yarn@1.22.22

changed 1 package in 596ms
sentry macbook-work py › devenv sync
installing yarn 1.22.22...

changed 1 package in 408ms
failed to install yarn 1.22.22!
```