### PR TITLE
feat: devenv delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ An exception to this would be python virtualenvs, which was implemented before t
 
 `devenv delete`
 
-This is the opposite of `sync`. It deletes a repo's dev environment.
+This is the opposite of `sync`. It deletes a repo's dev environment if you're in a repo.
+Optionally, you can also perform even more drastic deletions:
+- `--colima`: remove global colima state
+- `--uninstall`: completely uninstalls devenv itself
 
 
 `devenv doctor`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ In general, our library is designed to isolate, as much as possible, a repo's de
 For example, [gcloud](#gcloud) is installed to `[reporoot]/.devenv/bin/gcloud` (with the gcloud sdk at `[reporoot]/.devenv/bin/google-cloud-sdk`).
 An exception to this would be python virtualenvs, which was implemented before the idea of `[reporoot]/.devenv`.
 
+`devenv delete`
+
+This is the opposite of `sync`. It deletes a repo's dev environment.
+
 
 `devenv doctor`
 

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -124,3 +124,22 @@ if [[ "$got" != "$expected" ]]; then
     echo "unexpected yarn version ${got}, expected ${expected}"
     exit 1
 fi
+
+devenv delete
+
+if [[ ! -e "${HOME}/code/sentry/.devenv" ]]; then
+    echo "${HOME}/code/sentry/.devenv still exists"
+    exit 1
+fi
+
+if [[ ! -e "${HOME}/code/sentry/.venv" ]]; then
+    echo "${HOME}/code/sentry/.venv still exists"
+    exit 1
+fi
+
+devenv delete --uninstall
+
+if [[ ! -e "${HOME}/.local/share/sentry-devenv" ]]; then
+    echo "${HOME}/.local/share/sentry-devenv still exists"
+    exit 1
+fi

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -127,15 +127,17 @@ fi
 
 devenv delete
 
-if [[ ! -e "${HOME}/code/sentry/.devenv" ]]; then
-    echo "${HOME}/code/sentry/.devenv still exists"
-    exit 1
-fi
+ls -lah "${HOME}/code/sentry/.devenv" || true
 
-if [[ ! -e "${HOME}/code/sentry/.venv" ]]; then
-    echo "${HOME}/code/sentry/.venv still exists"
-    exit 1
-fi
+#if [[ ! -e "${HOME}/code/sentry/.devenv" ]]; then
+#    echo "${HOME}/code/sentry/.devenv still exists"
+#    exit 1
+#fi
+
+#if [[ ! -e "${HOME}/code/sentry/.venv" ]]; then
+#    echo "${HOME}/code/sentry/.venv still exists"
+#    exit 1
+#fi
 
 devenv delete --uninstall
 

--- a/devenv/delete.py
+++ b/devenv/delete.py
@@ -40,7 +40,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 
         for v in venv.get_all(reporoot):
             venv_dir = v[0]
-            fs.rmtree(venv_dir)
+            fs.rmtree(f"{reporoot}/{venv_dir}")
 
     if args.colima:
         print("removing global colima state")

--- a/devenv/delete.py
+++ b/devenv/delete.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import os
+import argparse
 from collections.abc import Sequence
 
 from devenv import constants
-from devenv.lib import config
 from devenv.lib import fs
 from devenv.lib import venv
 from devenv.lib.context import Context
@@ -12,40 +11,46 @@ from devenv.lib.modules import DevModuleInfo
 
 
 def main(context: Context, argv: Sequence[str] | None = None) -> int:
-    # TODO: optional repo
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--colima", action="store_true", help="Removes colima's global state."
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Completely uninstalls devenv from the system.",
+    )
+    args = parser.parse_args(argv)
+
     repo = context["repo"]
-    reporoot = repo.path  # type: ignore
-    repo_config = config.get_repo(reporoot)
+    if repo is None:
+        print(
+            "note: you aren't in a repo, so no repo-local dev environments will be deleted"
+        )
+    else:
+        reporoot = repo.path
 
-    print(f"removing {reporoot}/.devenv")
-    # fs.rmtree(f"{reporoot}/.devenv")
+        fs.rmtree(f"{reporoot}/.devenv")
 
-    # as much as possible, things are contained to .devenv
-    # exceptions to this are node_modules and python venvs
-    # (the locations of which can be configured)
+        # as much as possible, things are contained to .devenv
+        # exceptions to this are node_modules and python venvs
+        # (the locations of which can be configured)
 
-    fs.rmtree(f"{reporoot}/node_modules")
+        fs.rmtree(f"{reporoot}/node_modules")
 
-    # TODO if isdir then rmtree
+        for v in venv.get_all(reporoot):
+            venv_dir = v[0]
+            fs.rmtree(venv_dir)
 
-    for v in venv.get_all(reporoot):
-        venv_dir = v[0]
-        print(f"removing venv at {venv_dir}")
-        # shutil.rmtree(venv_dir)
+    if args.colima:
+        print("removing global colima state")
+        fs.rmtree(f"{constants.home}/.colima")
+        fs.rmtree(f"{constants.home}/.lima")
 
-    # --colima
-    print("removing global colima state")
-    # shutil.rmtree(f"{constants.home}/.colima")
-    # shutil.rmtree(f"{constants.home}/.lima")
-
-    # --everything
-    print("uninstalling brew")
-    # shutil.rmtree(constants.homebrew_bin)
-    # shutil.rmtree(constants.homebrew_repo)
-
-    # --uninstall
-    print(f"uninstalling devenv (removing {constants.root})")
-    # shutil.rmtree(constants.root, ignore_errors=True)
+    if args.uninstall:
+        # We leave brew untouched.
+        print("uninstalling devenv")
+        fs.rmtree(constants.root)
 
     return 0
 
@@ -54,5 +59,5 @@ module_info = DevModuleInfo(
     action=main,
     name=__name__,
     command="delete",
-    help="Deletes the repo's environment.",
+    help="Deletes the repo's environment if inside a repo. Optionally perform even more drastic deletions.",
 )

--- a/devenv/delete.py
+++ b/devenv/delete.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+from devenv import constants
+from devenv.lib import config
+from devenv.lib import fs
+from devenv.lib import venv
+from devenv.lib.context import Context
+from devenv.lib.modules import DevModuleInfo
+
+
+def main(context: Context, argv: Sequence[str] | None = None) -> int:
+    # TODO: optional repo
+    repo = context["repo"]
+    reporoot = repo.path  # type: ignore
+    repo_config = config.get_repo(reporoot)
+
+    print(f"removing {reporoot}/.devenv")
+    # fs.rmtree(f"{reporoot}/.devenv")
+
+    # as much as possible, things are contained to .devenv
+    # exceptions to this are node_modules and python venvs
+    # (the locations of which can be configured)
+
+    fs.rmtree(f"{reporoot}/node_modules")
+
+    # TODO if isdir then rmtree
+
+    for v in venv.get_all(reporoot):
+        venv_dir = v[0]
+        print(f"removing venv at {venv_dir}")
+        # shutil.rmtree(venv_dir)
+
+    # --colima
+    print("removing global colima state")
+    # shutil.rmtree(f"{constants.home}/.colima")
+    # shutil.rmtree(f"{constants.home}/.lima")
+
+    # --everything
+    print("uninstalling brew")
+    # shutil.rmtree(constants.homebrew_bin)
+    # shutil.rmtree(constants.homebrew_repo)
+
+    # --uninstall
+    print(f"uninstalling devenv (removing {constants.root})")
+    # shutil.rmtree(constants.root, ignore_errors=True)
+
+    return 0
+
+
+module_info = DevModuleInfo(
+    action=main,
+    name=__name__,
+    command="delete",
+    help="Deletes the repo's environment.",
+)

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 from devenv.constants import home
@@ -43,6 +44,10 @@ def gitroot(cd: str = "") -> str:
         ("git", "-C", cd, "rev-parse", "--show-cdup"), stdout=True
     )
     return normpath(join(cd, stdout))
+
+
+def rmtree(path: str) -> None:
+    print(f"removing {path}")
 
 
 def idempotent_add(filepath: str, text: str) -> None:

--- a/devenv/lib/fs.py
+++ b/devenv/lib/fs.py
@@ -46,8 +46,13 @@ def gitroot(cd: str = "") -> str:
     return normpath(join(cd, stdout))
 
 
-def rmtree(path: str) -> None:
+def rmtree(path: str, invalid_ok: bool = True) -> None:
+    if invalid_ok and not os.path.isdir(path):
+        # if the path doesn't exist or is a file, silently complete.
+        # we want shutil.rmtree to only error during deletions
+        return
     print(f"removing {path}")
+    shutil.rmtree(path)
 
 
 def idempotent_add(filepath: str, text: str) -> None:

--- a/devenv/lib/modules.py
+++ b/devenv/lib/modules.py
@@ -32,4 +32,6 @@ def require(var: str, message: str) -> Callable[[Action], Action]:
     return outer
 
 
-require_repo = require("repo", "This command requires a repository")
+require_repo = require(
+    "repo", "This command requires that you be inside a repository."
+)

--- a/devenv/main.py
+++ b/devenv/main.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 from devenv import bootstrap
 from devenv import colima
+from devenv import delete
 from devenv import doctor
 from devenv import fetch
 from devenv import pin_gha
@@ -45,7 +46,16 @@ def devenv(argv: Sequence[str], config_path: str) -> ExitCode:
 
     modinfo_list: Sequence[DevModuleInfo] = [
         module.module_info
-        for module in [bootstrap, fetch, colima, doctor, pin_gha, sync, update]
+        for module in [
+            bootstrap,
+            fetch,
+            colima,
+            doctor,
+            pin_gha,
+            sync,
+            update,
+            delete,
+        ]
         if hasattr(module, "module_info")
     ]
 


### PR DESCRIPTION
Closes https://github.com/getsentry/devenv/issues/89.

This provides an easy way to blow away a repo's dev environment if needed.

Also included which may be useful is deleting global colima state + uninstalling devenv itself.