### PR TITLE
feat: new stripN and ability to download blobs from homebrew

### DIFF
--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -90,7 +90,7 @@ def download(
 # strips N leading components and optionally adds a new prefix
 # (what ends up being stripped should be a common prefix for all entries)
 # (/ is always stripped and doesn't count)
-def stripN(
+def strip_n(
     members: Sequence[tarfile.TarInfo], strip_n: int, new_prefix: str = ""
 ) -> None:
     # we'll use the first member to determine the prefix to strip
@@ -108,7 +108,7 @@ def stripN(
             # this means this member isn't nested as deep as
             # N directories we want to strip, which is
             # unexpected
-            raise RuntimeError(
+            raise ValueError(
                 f"""unexpected archive structure:
 
 trying to strip {strip_n} leading components but {member.path} isn't that deep
@@ -120,7 +120,7 @@ trying to strip {strip_n} leading components but {member.path} isn't that deep
 
     for member in members:
         if not member.path.startswith(stripped_prefix):
-            raise RuntimeError(
+            raise ValueError(
                 f"""unexpected archive structure:
 
 {member.path} doesn't have the prefix to be removed ({stripped_prefix})
@@ -134,7 +134,7 @@ trying to strip {strip_n} leading components but {member.path} isn't that deep
 
 
 def strip1(members: Sequence[tarfile.TarInfo], new_prefix: str = "") -> None:
-    stripN(members, 1, new_prefix)
+    strip_n(members, 1, new_prefix)
 
 
 def unpack(
@@ -150,10 +150,8 @@ def unpack(
         tarf.extractall(into, filter="tar")
 
 
-def unpack_strip_n(
-    path: str, into: str, strip_n: int, new_prefix: str = ""
-) -> None:
+def unpack_strip_n(path: str, into: str, n: int, new_prefix: str = "") -> None:
     os.makedirs(into, exist_ok=True)
     with tarfile.open(name=path, mode="r:*") as tarf:
-        stripN(tarf.getmembers(), strip_n, new_prefix)
+        strip_n(tarf.getmembers(), n, new_prefix)
         tarf.extractall(into, filter="tar")

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -117,7 +117,21 @@ trying to strip {strip_n} leading components but {member.path} isn't that deep
         end += next_at + 1
 
     stripped_prefix = member.path[:end]
-    breakpoint()
+
+    if end == 0:
+        if strip_n == 1:
+            # A common case where the first member is the directory
+            # to be stripped. In a python TarInfo object it won't have
+            # a trailing slash.
+            stripped_prefix = member.path[:]
+            end = len(stripped_prefix)
+        elif strip_n > 1:
+            raise ValueError(
+                f"""unexpected archive structure:
+
+trying to strip {strip_n} leading components but {member.path} isn't that deep
+"""
+            )
 
     for member in members:
         if not member.path.startswith(stripped_prefix):

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -116,16 +116,8 @@ trying to strip {strip_n} leading components but {member.path} isn't that deep
             )
         end += next_at + 1
 
-    if end == 0 and strip_n > 0:
-        # special case where members are just top level files
-        raise ValueError(
-            f"""unexpected archive structure:
-
-trying to strip {strip_n} leading components but {member.path} isn't that deep
-"""
-        )
-
     stripped_prefix = member.path[:end]
+    breakpoint()
 
     for member in members:
         if not member.path.startswith(stripped_prefix):

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -91,22 +91,26 @@ def download(
 # the same component was stripped across all members
 # (/ is always stripped and doesn't count)
 def strip1(members: Sequence[tarfile.TarInfo]) -> None:
-    for member in members:
-        i = member.path.find("/")
-        if i == -1:
+    end = members[0].path.find("/")
+    if end == -1:
+        raise ValueError(
+            f"unexpected archive structure: no component left to strip in {members[0].path}"
+        )
+    elif end == 0:
+        end = members[0].path[1:].find("/") + 1
+        if end == 0:
             raise ValueError(
-                f"unexpected archive structure: no component left to strip in {member.path}"
+                f"unexpected archive structure: no component left to strip in {members[0].path}"
             )
-        elif i == 0:
-            i = member.path[1:].find("/") + 1
-            if i == 0:
-                raise ValueError(
-                    f"unexpected archive structure: no component left to strip in {member.path}"
-                )
 
-        member.path = member.path[i + 1 :]  # noqa: E203
+    first_stripped_component = members[0].path[: end + 1]
 
-    # TODO: assert that the same component was stripped across all members
+    for member in members:
+        if not member.path.startswith(first_stripped_component):
+            raise ValueError(
+                f"unexpected archive structure: leading component in {member.path} inconsistent with {first_stripped_component}"
+            )
+        member.path = member.path[end + 1 :]  # noqa: E203
 
 
 def unpack(

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -87,63 +87,26 @@ def download(
 
 
 # mutates members!
-# strips N leading components and optionally adds a new prefix
-# (what ends up being stripped should be a common prefix for all entries)
+# strips the leading component, and asserts that
+# the same component was stripped across all members
 # (/ is always stripped and doesn't count)
-def strip_n(
-    members: Sequence[tarfile.TarInfo], strip_n: int, new_prefix: str = ""
-) -> None:
-    # we'll use the first member to determine the prefix to strip
-    member = members[0]
-
-    end = 0
-    if member.path.find("/") == 0:
-        # strip leading "/"
-        end = 1
-
-    for n in range(strip_n):
-        next_at = member.path[end:].find("/")
-        if next_at == -1 and n != strip_n - 1:
-            # no more '/' but we're not done iterating
-            # this means this member isn't nested as deep as
-            # N directories we want to strip, which is
-            # unexpected
-            raise ValueError(
-                f"""unexpected archive structure:
-
-trying to strip {strip_n} leading components but {member.path} isn't that deep
-"""
-            )
-        end += next_at + 1
-
-    if end == 0 and strip_n > 0:
-        # special case where members are just top level files
-        raise ValueError(
-            f"""unexpected archive structure:
-
-trying to strip {strip_n} leading components but {member.path} isn't that deep
-"""
-        )
-
-    stripped_prefix = member.path[:end]
-
+def strip1(members: Sequence[tarfile.TarInfo]) -> None:
     for member in members:
-        if not member.path.startswith(stripped_prefix):
+        i = member.path.find("/")
+        if i == -1:
             raise ValueError(
-                f"""unexpected archive structure:
-
-{member.path} doesn't have the prefix to be removed ({stripped_prefix})
-"""
+                f"unexpected archive structure: no component left to strip in {member.path}"
             )
+        elif i == 0:
+            i = member.path[1:].find("/") + 1
+            if i == 0:
+                raise ValueError(
+                    f"unexpected archive structure: no component left to strip in {member.path}"
+                )
 
-        if new_prefix:
-            member.path = f"{new_prefix}/{member.path[end:]}"
-        else:
-            member.path = member.path[end:]
+        member.path = member.path[i + 1 :]  # noqa: E203
 
-
-def strip1(members: Sequence[tarfile.TarInfo], new_prefix: str = "") -> None:
-    strip_n(members, 1, new_prefix)
+    # TODO: assert that the same component was stripped across all members
 
 
 def unpack(
@@ -155,12 +118,23 @@ def unpack(
     os.makedirs(into, exist_ok=True)
     with tarfile.open(name=path, mode="r:*") as tarf:
         if perform_strip1:
-            strip1(tarf.getmembers(), strip1_new_prefix)
+            strip1(tarf.getmembers())
+
+        if strip1_new_prefix:
+            for member in tarf.getmembers():
+                member.path = f"{strip1_new_prefix}/{member.path}"
+
         tarf.extractall(into, filter="tar")
 
 
 def unpack_strip_n(path: str, into: str, n: int, new_prefix: str = "") -> None:
     os.makedirs(into, exist_ok=True)
     with tarfile.open(name=path, mode="r:*") as tarf:
-        strip_n(tarf.getmembers(), n, new_prefix)
+        for i in range(n):
+            strip1(tarf.getmembers())
+
+        if new_prefix:
+            for member in tarf.getmembers():
+                member.path = f"{new_prefix}/{member.path}"
+
         tarf.extractall(into, filter="tar")

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -91,26 +91,22 @@ def download(
 # the same component was stripped across all members
 # (/ is always stripped and doesn't count)
 def strip1(members: Sequence[tarfile.TarInfo]) -> None:
-    end = members[0].path.find("/")
-    if end == -1:
-        raise ValueError(
-            f"unexpected archive structure: no component left to strip in {members[0].path}"
-        )
-    elif end == 0:
-        end = members[0].path[1:].find("/") + 1
-        if end == 0:
-            raise ValueError(
-                f"unexpected archive structure: no component left to strip in {members[0].path}"
-            )
-
-    first_stripped_component = members[0].path[: end + 1]
-
     for member in members:
-        if not member.path.startswith(first_stripped_component):
+        i = member.path.find("/")
+        if i == -1:
             raise ValueError(
-                f"unexpected archive structure: leading component in {member.path} inconsistent with {first_stripped_component}"
+                f"unexpected archive structure: no component left to strip in {member.path}"
             )
-        member.path = member.path[end + 1 :]  # noqa: E203
+        elif i == 0:
+            i = member.path[1:].find("/") + 1
+            if i == 0:
+                raise ValueError(
+                    f"unexpected archive structure: no component left to strip in {member.path}"
+                )
+
+        member.path = member.path[i + 1 :]  # noqa: E203
+
+    # TODO: assert that the same component was stripped across all members
 
 
 def unpack(

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -116,6 +116,15 @@ trying to strip {strip_n} leading components but {member.path} isn't that deep
             )
         end += next_at + 1
 
+    if end == 0 and strip_n > 0:
+        # special case where members are just top level files
+        raise ValueError(
+            f"""unexpected archive structure:
+
+trying to strip {strip_n} leading components but {member.path} isn't that deep
+"""
+        )
+
     stripped_prefix = member.path[:end]
 
     for member in members:

--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -38,10 +38,20 @@ def download(
         os.makedirs(cache_root, exist_ok=True)
 
     if not os.path.exists(dest):
+        headers = {}
+        if url.startswith("https://ghcr.io/v2/homebrew"):
+            # downloading homebrew blobs requires auth
+            # you can get an anonymous token from https://ghcr.io/token?service=ghcr.io&scope=repository%3Ahomebrew/core/go%3Apull
+            # but there's also a special shortcut token QQ==
+            # https://github.com/Homebrew/brew/blob/2184406bd8444e4de2626f5b0c749d4d08cb1aed/Library/Homebrew/brew.sh#L993
+            headers["Authorization"] = "bearer QQ=="
+
+        req = urllib.request.Request(url, headers=headers)
+
         retry_sleep = 1.0
         while retries >= 0:
             try:
-                resp = urllib.request.urlopen(url)
+                resp = urllib.request.urlopen(req)
                 break
             except HTTPError as e:
                 if retries == 0:
@@ -77,22 +87,54 @@ def download(
 
 
 # mutates members!
-# strips the leading component (/ is always stripped and doesn't count)
-# and optionally replaces with a new prefix
-def strip1(members: Sequence[tarfile.TarInfo], new_prefix: str = "") -> None:
-    for member in members:
-        i = member.path.find("/")
-        if i == -1:
-            continue
-        elif i == 0:
-            i = member.path[1:].find("/") + 1
-            if i == 0:
-                continue
+# strips N leading components and optionally adds a new prefix
+# (what ends up being stripped should be a common prefix for all entries)
+# (/ is always stripped and doesn't count)
+def stripN(
+    members: Sequence[tarfile.TarInfo], strip_n: int, new_prefix: str = ""
+) -> None:
+    # we'll use the first member to determine the prefix to strip
+    member = members[0]
 
-        member.path = member.path[i + 1 :]  # noqa: E203
+    end = 0
+    if member.path.find("/") == 0:
+        # strip leading "/"
+        end = 1
+
+    for n in range(strip_n):
+        next_at = member.path[end:].find("/")
+        if next_at == -1 and n != strip_n - 1:
+            # no more '/' but we're not done iterating
+            # this means this member isn't nested as deep as
+            # N directories we want to strip, which is
+            # unexpected
+            raise RuntimeError(
+                f"""unexpected archive structure:
+
+trying to strip {strip_n} leading components but {member.path} isn't that deep
+"""
+            )
+        end += next_at + 1
+
+    stripped_prefix = member.path[:end]
+
+    for member in members:
+        if not member.path.startswith(stripped_prefix):
+            raise RuntimeError(
+                f"""unexpected archive structure:
+
+{member.path} doesn't have the prefix to be removed ({stripped_prefix})
+"""
+            )
 
         if new_prefix:
-            member.path = f"{new_prefix}/{member.path}"
+            member.path = f"{new_prefix}/{member.path[end:]}"
+        else:
+            member.path = member.path[end:]
+
+
+def strip1(members: Sequence[tarfile.TarInfo], new_prefix: str = "") -> None:
+    stripN(members, 1, new_prefix)
 
 
 def unpack(
@@ -105,4 +147,13 @@ def unpack(
     with tarfile.open(name=path, mode="r:*") as tarf:
         if perform_strip1:
             strip1(tarf.getmembers(), strip1_new_prefix)
+        tarf.extractall(into, filter="tar")
+
+
+def unpack_strip_n(
+    path: str, into: str, strip_n: int, new_prefix: str = ""
+) -> None:
+    os.makedirs(into, exist_ok=True)
+    with tarfile.open(name=path, mode="r:*") as tarf:
+        stripN(tarf.getmembers(), strip_n, new_prefix)
         tarf.extractall(into, filter="tar")

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -180,24 +180,24 @@ def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
     assert os.path.exists(f"{tmp_path}/dest2/node/baz")
 
 
-def test_unpack_stripN(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
+def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
     dest = tmp_path.joinpath("dest")
-    archive.unpack_strip_n(str(tar2), str(dest), strip_n=2)
+    archive.unpack_strip_n(str(tar2), str(dest), n=2)
     assert os.path.exists(f"{tmp_path}/dest/bin/foo")
     assert os.path.exists(f"{tmp_path}/dest/baz")
 
     dest2 = tmp_path.joinpath("dest2")
-    archive.unpack_strip_n(str(tar2), str(dest2), strip_n=2, new_prefix="x")
+    archive.unpack_strip_n(str(tar2), str(dest2), n=2, new_prefix="x")
     assert os.path.exists(f"{tmp_path}/dest2/x/bin/foo")
     assert os.path.exists(f"{tmp_path}/dest2/x/baz")
 
 
-def test_unpack_stripN_unexpected_structure(
+def test_unpack_strip_n_unexpected_structure(
     tar3: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
     dest = tmp_path.joinpath("dest")
-    with pytest.raises(RuntimeError) as excinfo:
-        archive.unpack_strip_n(str(tar3), str(dest), strip_n=2)
+    with pytest.raises(ValueError) as excinfo:
+        archive.unpack_strip_n(str(tar3), str(dest), n=2)
 
     assert (
         f"{excinfo.value}"

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -173,10 +173,7 @@ def test_unpack_tar_strip1(tar: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
     assert (
         f"{excinfo.value}"
-        == """unexpected archive structure:
-
-trying to strip 1 leading components but hello.txt isn't that deep
-"""
+        == "unexpected archive structure: no component left to strip in hello.txt"
     )
 
 
@@ -215,10 +212,7 @@ def test_unpack_strip_n_unexpected_structure(
 
     assert (
         f"{excinfo.value}"
-        == """unexpected archive structure:
-
-foo/bad doesn't have the prefix to be removed (foo/v1/)
-"""
+        == "unexpected archive structure: no component left to strip in bad"
     )
 
 

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -173,7 +173,10 @@ def test_unpack_tar_strip1(tar: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
     assert (
         f"{excinfo.value}"
-        == "unexpected archive structure: no component left to strip in hello.txt"
+        == """unexpected archive structure:
+
+trying to strip 1 leading components but hello.txt isn't that deep
+"""
     )
 
 
@@ -212,7 +215,10 @@ def test_unpack_strip_n_unexpected_structure(
 
     assert (
         f"{excinfo.value}"
-        == "unexpected archive structure: no component left to strip in bad"
+        == """unexpected archive structure:
+
+foo/bad doesn't have the prefix to be removed (foo/v1/)
+"""
     )
 
 

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -90,6 +90,22 @@ def tar4(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
+def tar5(tmp_path: pathlib.Path) -> pathlib.Path:
+    a = tmp_path.joinpath("a")
+    a.write_text("")
+    b = tmp_path.joinpath("b")
+    b.write_text("")
+
+    tar = tmp_path.joinpath("tar")
+
+    with tarfile.open(tar, "w:tar") as tarf:
+        tarf.add(a, arcname="foo/v1/bar")
+        tarf.add(b, arcname="foo/v2/baz")
+
+    return tar
+
+
+@pytest.fixture
 def mock_sleep() -> typing.Generator[mock.MagicMock, None, None]:
     with mock.patch.object(time, "sleep", autospec=True) as mock_sleep:
         yield mock_sleep
@@ -234,3 +250,19 @@ def test_unpack_strip_n_root(
     archive.unpack_strip_n(str(tar4), str(dest2), n=0)
     # n=0 can be used to just strip the root component
     assert os.path.exists(f"{tmp_path}/dest/foo/bar")
+
+
+def test_unpack_strip_n_unexpected_structure_inconsistent_components(
+    tar5: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    dest = tmp_path.joinpath("dest")
+    with pytest.raises(ValueError) as excinfo:
+        archive.unpack_strip_n(str(tar5), str(dest), n=2)
+
+    assert (
+        f"{excinfo.value}"
+        == """unexpected archive structure:
+
+foo/v2/baz doesn't have the prefix to be removed (foo/v1/)
+"""
+    )

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -90,22 +90,6 @@ def tar4(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
-def tar5(tmp_path: pathlib.Path) -> pathlib.Path:
-    a = tmp_path.joinpath("a")
-    a.write_text("")
-    b = tmp_path.joinpath("b")
-    b.write_text("")
-
-    tar = tmp_path.joinpath("tar")
-
-    with tarfile.open(tar, "w:tar") as tarf:
-        tarf.add(a, arcname="foo/v1/bar")
-        tarf.add(b, arcname="foo/v2/baz")
-
-    return tar
-
-
-@pytest.fixture
 def mock_sleep() -> typing.Generator[mock.MagicMock, None, None]:
     with mock.patch.object(time, "sleep", autospec=True) as mock_sleep:
         yield mock_sleep
@@ -228,8 +212,7 @@ def test_unpack_strip_n_unexpected_structure(
 
     assert (
         f"{excinfo.value}"
-        # technically should be "no component left to strip in bad" but w/e
-        == "unexpected archive structure: leading component in bad inconsistent with v1/"
+        == "unexpected archive structure: no component left to strip in bad"
     )
 
 
@@ -245,16 +228,3 @@ def test_unpack_strip_n_root(
     archive.unpack_strip_n(str(tar4), str(dest2), n=0)
     # n=0 can be used to just strip the root component
     assert os.path.exists(f"{tmp_path}/dest/foo/bar")
-
-
-def test_unpack_strip_n_unexpected_structure_inconsistent_components(
-    tar5: pathlib.Path, tmp_path: pathlib.Path
-) -> None:
-    dest = tmp_path.joinpath("dest")
-    with pytest.raises(ValueError) as excinfo:
-        archive.unpack_strip_n(str(tar5), str(dest), n=2)
-
-    assert (
-        f"{excinfo.value}"
-        == "unexpected archive structure: leading component in v2/baz inconsistent with v1/"
-    )

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -91,16 +91,21 @@ def tar4(tmp_path: pathlib.Path) -> pathlib.Path:
 
 @pytest.fixture
 def tar5(tmp_path: pathlib.Path) -> pathlib.Path:
-    a = tmp_path.joinpath("a")
-    a.write_text("")
-    b = tmp_path.joinpath("b")
-    b.write_text("")
+    foo = tmp_path / "foo"
+    foo.mkdir()
+    foo_v1 = tmp_path / "foo/v1"
+    foo_v1.mkdir()
+    foo_v2 = tmp_path / "foo/v2"
+    foo_v2.mkdir()
+    foo_v1_bar = foo_v1 / "bar"
+    foo_v1_bar.write_text("")
+    foo_v2_baz = foo_v2 / "baz"
+    foo_v2_baz.write_text("")
 
     tar = tmp_path.joinpath("tar")
 
     with tarfile.open(tar, "w:tar") as tarf:
-        tarf.add(a, arcname="foo/v1/bar")
-        tarf.add(b, arcname="foo/v2/baz")
+        tarf.add(foo, arcname="foo")
 
     return tar
 
@@ -117,7 +122,6 @@ def tar6(tmp_path: pathlib.Path) -> pathlib.Path:
     tar = tmp_path.joinpath("tar")
 
     with tarfile.open(tar, "w:tar") as tarf:
-        # real world example, the first member is the top level directory itself
         tarf.add(a, arcname="node-v20.13.1-linux-x64")
         tarf.add(b, arcname="node-v20.13.1-linux-x64/bin")
         tarf.add(c, arcname="node-v20.13.1-linux-x64/bin/node")
@@ -269,7 +273,7 @@ def test_unpack_strip_n_unexpected_structure_inconsistent_components(
         f"{excinfo.value}"
         == """unexpected archive structure:
 
-foo/v2/baz doesn't have the prefix to be removed (foo/v1/)
+trying to strip 2 leading components but foo isn't that deep
 """
     )
 


### PR DESCRIPTION
tl;dr we need to upgrade to limactl 0.23.2 and only the homebrew builds work since their github releases aren't compiled for macos 14+, and the vast majority of limactl consumers get it from homebrew

https://github.com/getsentry/devenv/issues/146#issuecomment-2384323691

their homebrew releases have a different structure - a `lima/0.23.2` prefix - so we do need a stripN after all

i've also improved the implementation, it now determines the prefix to be stripped one time then expects to strip that same prefix from all members - otherwise it's an unexpected structure

