### PR TITLE
ref: colima shim

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   bootstrap:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -42,7 +43,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,7 +19,6 @@ env:
 
 jobs:
   bootstrap:
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -43,7 +42,7 @@ jobs:
   bootstrap-macos-13:
     # This job takes half an hour and costs a lot of money.
     # Let's just run on main commits.
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: macos-13
     timeout-minutes: 60
     env:

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import platform
 import shutil
-import sys
 import tempfile
 from enum import Enum
 
@@ -49,18 +48,9 @@ export COLIMA_HOME="{home}/.colima"
 # needed to ensure COLIMA_HOME is what we want it to be
 unset XDG_CONFIG_HOME
 
-# no one is going to type 'devenv colima start'
-# but it's very important that colima is started with the
-# right parameters
-for arg in "$@"; do
-  if [ "$arg" = "start" ]; then
-    exec "{py}" -P -m devenv colima start
-  fi
-done
-
 exec "{binroot}/colima-bin" "$@"
 """,
-        shell_escape={"binroot": binroot, "home": home, "py": sys.executable},
+        shell_escape={"binroot": binroot, "home": home},
     )
 
 

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -43,12 +43,12 @@ def install_shim(binroot: str) -> None:
     fs.write_script(
         f"{binroot}/colima",
         """#!/bin/sh
-export COLIMA_HOME="{home}/.colima"
+export COLIMA_HOME={home}/.colima
 
 # needed to ensure COLIMA_HOME is what we want it to be
 unset XDG_CONFIG_HOME
 
-exec "{binroot}/colima-bin" "$@"
+exec {binroot}/colima-bin "$@"
 """,
         shell_escape={"binroot": binroot, "home": home},
     )

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -14,7 +14,7 @@ from devenv.lib import fs
 from devenv.lib import proc
 from devenv.lib import rosetta
 
-
+COLIMA_HOME = f"{home}/.colima"
 ColimaStatus = Enum("ColimaStatus", ("UP", "DOWN", "UNHEALTHY"))
 
 
@@ -44,7 +44,7 @@ def install_shim(binroot: str) -> None:
     fs.write_script(
         f"{binroot}/colima",
         """#!/bin/sh
-export COLIMA_HOME="{home}/.colima"
+export COLIMA_HOME="{COLIMA_HOME}"
 
 # needed to ensure COLIMA_HOME is what we want it to be
 unset XDG_CONFIG_HOME
@@ -60,7 +60,11 @@ done
 
 exec "{binroot}/colima-bin" "$@"
 """,
-        shell_escape={"binroot": binroot, "home": home, "py": sys.executable},
+        shell_escape={
+            "binroot": binroot,
+            "COLIMA_HOME": COLIMA_HOME,
+            "py": sys.executable,
+        },
     )
 
 
@@ -103,13 +107,13 @@ def check(reporoot: str) -> ColimaStatus:
             "docker executable not found, you might want to run devenv sync"
         )
 
-    colima = f"{reporoot}/.devenv/bin/colima"
+    colima = f"{reporoot}/.devenv/bin/colima-bin"
     if not os.path.isfile(colima):
         raise SystemExit(
             f"colima not found at {colima}, you might want to run devenv sync"
         )
 
-    if not os.path.exists(f"{home}/.colima/default/docker.sock"):
+    if not os.path.exists(f"{COLIMA_HOME}/default/docker.sock"):
         return ColimaStatus.DOWN
 
     # if colima's up, we should be able to communicate with that docker socket
@@ -135,12 +139,12 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     if status == ColimaStatus.UP:
         if not restart:
             return ColimaStatus.UP
-        proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+        proc.run(("colima-bin", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
     elif status == ColimaStatus.DOWN:
         pass
     elif status == ColimaStatus.UNHEALTHY:
         print("colima seems to be unhealthy, stopping it")
-        proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+        proc.run(("colima-bin", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
 
     # colima start will only WARN if rosetta is unavailable and keep going without it,
     # so we need to ensure it's installed and running ourselves
@@ -165,7 +169,7 @@ def start(reporoot: str, restart: bool = False) -> ColimaStatus:
     proc.run(
         (
             # we share the "default" machine across repositories
-            "colima",
+            "colima-bin",
             "start",
             "--verbose",
             # ideally we keep ~ ro and reporoot rw, but currently the "default" vm
@@ -188,6 +192,6 @@ def restart(reporoot: str) -> ColimaStatus:
 
 
 def stop(reporoot: str) -> ColimaStatus:
-    proc.run(("colima", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
+    proc.run(("colima-bin", "stop"), pathprepend=f"{reporoot}/.devenv/bin")
     status = check(reporoot)
     return status


### PR DESCRIPTION
this adds a shim for colima that:

1. <s>if start, reexecs as `devenv colima start` - some people in the past have run `colima delete` then `colima start` to try and reset state, however `colima start` has bad defaults and (currently) suffers from double-start problem which `devenv colima start` solves</s>

2. proactively ensures that COLIMA_HOME is ~/.colima. The version I'm trying to upgrade us to prioritizes using XDG_CONFIG_HOME (https://github.com/abiosoft/colima/commit/05fd57766899b5b9c3eed14e8889083a546e3353) if set.