### PR TITLE
feat: strip_n and ability to download blobs from homebrew (take 2)

### DIFF
--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -8,6 +8,7 @@ import tarfile
 import tempfile
 import time
 import urllib.request
+from collections.abc import Generator
 from collections.abc import Sequence
 from urllib.error import HTTPError
 
@@ -115,7 +116,7 @@ def unpack(
     with tarfile.open(name=path, mode="r:*") as tarf:
         members = tarf.getmembers()
         if perform_strip1:
-            members = strip1(members)
+            members = [_ for _ in strip1(members)]
 
         if strip1_new_prefix:
             for member in members:
@@ -130,7 +131,7 @@ def unpack_strip_n(path: str, into: str, n: int, new_prefix: str = "") -> None:
         members = tarf.getmembers()
 
         for _ in range(n):
-            members = strip1(members)
+            members = [_ for _ in strip1(members)]
 
         if new_prefix:
             for member in members:

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -201,15 +201,16 @@ def test_unpack_tar(tar: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
 
 def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
-    dest = tmp_path.joinpath("dest")
-    archive.unpack(str(tgz), str(dest), perform_strip1=True)
-    assert os.path.exists(f"{tmp_path}/dest/bin/foo")
-    assert os.path.exists(f"{tmp_path}/dest/baz")
+    #    dest = tmp_path.joinpath("dest")
+    #    archive.unpack(str(tgz), str(dest), perform_strip1=True)
+    #    assert os.path.exists(f"{tmp_path}/dest/bin/foo")
+    #    assert os.path.exists(f"{tmp_path}/dest/baz")
 
     dest2 = tmp_path.joinpath("dest2")
     archive.unpack(
         str(tgz), str(dest2), perform_strip1=True, strip1_new_prefix="node"
     )
+    # breakpoint()
     assert os.path.exists(f"{tmp_path}/dest2/node/bin/foo")
     assert os.path.exists(f"{tmp_path}/dest2/node/baz")
 

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -198,13 +198,13 @@ def test_download(tmp_path: pathlib.Path, mock_sleep: mock.MagicMock) -> None:
 
 
 def test_unpack_tar(tar: pathlib.Path, tmp_path: pathlib.Path) -> None:
-    dest = tmp_path.joinpath("dest")
+    dest = tmp_path / "dest"
     archive.unpack(str(tar), str(dest))
-    assert dest.joinpath("executable").read_text() == "hi"
+    assert (dest / "executable").read_text() == "hi"
 
 
 def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
-    dest = tmp_path.joinpath("dest")
+    dest = tmp_path / "dest"
     archive.unpack(str(tgz), str(dest), perform_strip1=True)
 
     assert [x for x in os.walk(dest)] == [
@@ -214,7 +214,7 @@ def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
         (f"{dest}/bin", [], ["foo"]),
     ]
 
-    dest2 = tmp_path.joinpath("dest2")
+    dest2 = tmp_path / "dest2"
     archive.unpack(
         str(tgz), str(dest2), perform_strip1=True, strip1_new_prefix="node"
     )
@@ -229,7 +229,7 @@ def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
 
 
 def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
-    dest = tmp_path.joinpath("dest")
+    dest = tmp_path / "dest"
     archive.unpack_strip_n(str(tar2), str(dest), n=2)
     assert [x for x in os.walk(dest)] == [
         # baz
@@ -239,7 +239,7 @@ def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
         (f"{dest}/baz", [], []),
     ]
 
-    dest2 = tmp_path.joinpath("dest2")
+    dest2 = tmp_path / "dest2"
     archive.unpack_strip_n(str(tar2), str(dest2), n=2, new_prefix="x")
     assert [x for x in os.walk(dest2)] == [
         # x/baz
@@ -254,7 +254,7 @@ def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
 def test_unpack_strip_n_unconditionally_removed(
     tar3: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
-    dest = tmp_path.joinpath("dest")
+    dest = tmp_path / "dest"
     archive.unpack_strip_n(str(tar3), str(dest), n=2)
 
     # foo/bar is unconditionally removed
@@ -268,7 +268,7 @@ def test_unpack_strip_n_unconditionally_removed(
 def test_unpack_strip_n_root(
     tar4: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
-    dest = tmp_path.joinpath("dest")
+    dest = tmp_path / "dest"
     archive.unpack_strip_n(str(tar4), str(dest), n=1)
     # leading slash in /foo/bar doesn't count as a component
 
@@ -277,16 +277,12 @@ def test_unpack_strip_n_root(
         (f"{dest}", [], ["bar"])
     ]
 
-    dest2 = tmp_path.joinpath("dest")
+    dest2 = tmp_path / "dest2"
     archive.unpack_strip_n(str(tar4), str(dest2), n=0)
     # n=0 can be used to just strip the root component
 
-    # problem, we now have
-    # bar
-    # foo/bar
-
     assert [x for x in os.walk(dest2)] == [
         # foo/bar
-        (f"{dest}", ["foo"], ["bar"]),
-        (f"{dest}/foo", [], ["bar"]),
+        (f"{dest2}", ["foo"], []),
+        (f"{dest2}/foo", [], ["bar"]),
     ]

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -206,22 +206,31 @@ def test_unpack_tar(tar: pathlib.Path, tmp_path: pathlib.Path) -> None:
 def test_unpack_tgz_strip1(tgz: pathlib.Path, tmp_path: pathlib.Path) -> None:
     dest = tmp_path.joinpath("dest")
     archive.unpack(str(tgz), str(dest), perform_strip1=True)
-    assert os.path.exists(f"{tmp_path}/dest/bin/foo")
-    assert os.path.exists(f"{tmp_path}/dest/baz")
+
+    assert [x for x in os.walk(dest)] == [
+        # bin/foo
+        # baz
+        (f"{dest}", ["bin"], ["baz"]),
+        (f"{dest}/bin", [], ["foo"]),
+    ]
 
     dest2 = tmp_path.joinpath("dest2")
     archive.unpack(
         str(tgz), str(dest2), perform_strip1=True, strip1_new_prefix="node"
     )
-    assert os.path.exists(f"{tmp_path}/dest2/node/bin/foo")
-    assert os.path.exists(f"{tmp_path}/dest2/node/baz")
+
+    assert [x for x in os.walk(dest2)] == [
+        # node/bin/foo
+        # node/baz
+        (f"{dest2}", ["node"], []),
+        (f"{dest2}/node", ["bin"], ["baz"]),
+        (f"{dest2}/node/bin", [], ["foo"]),
+    ]
 
 
 def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
     dest = tmp_path.joinpath("dest")
     archive.unpack_strip_n(str(tar2), str(dest), n=2)
-    assert os.path.exists(f"{tmp_path}/dest/bin/foo")
-    assert os.path.exists(f"{tmp_path}/dest/baz")
     assert [x for x in os.walk(dest)] == [
         # baz
         # bin/foo

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -85,8 +85,8 @@ def tar3(tmp_path: pathlib.Path) -> pathlib.Path:
     foo = tmp_path / "foo"
     foo.mkdir()
 
-    foo_bad = tmp_path / "foo/bad"
-    foo_bad.write_text("")
+    foo_bar = tmp_path / "foo/bar"
+    foo_bar.write_text("")
 
     foo_v1 = tmp_path / "foo/v1"
     foo_v1.mkdir()
@@ -98,7 +98,7 @@ def tar3(tmp_path: pathlib.Path) -> pathlib.Path:
     with tarfile.open(tar, "w:tar") as tarf:
         tarf.add(foo, arcname="foo")
         # foo
-        # foo/bad
+        # foo/bar
         # foo/v1
         # foo/v1/foo
 
@@ -226,20 +226,18 @@ def test_unpack_strip_n(tar2: pathlib.Path, tmp_path: pathlib.Path) -> None:
     assert os.path.exists(f"{tmp_path}/dest2/x/baz")
 
 
-def test_unpack_strip_n_unexpected_structure(
+def test_unpack_strip_n_unconditionally_removed(
     tar3: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
     dest = tmp_path.joinpath("dest")
-    with pytest.raises(ValueError) as excinfo:
-        archive.unpack_strip_n(str(tar3), str(dest), n=2)
+    archive.unpack_strip_n(str(tar3), str(dest), n=2)
 
-    # fail because we don't catch this
-    # [<TarInfo 'foo' at 0x1041fa080>, <TarInfo 'bad' at 0x1041f9f00>, <TarInfo 'v1' at 0x1041f9e40>, <TarInfo 'foo' at 0x1041f9cc0>]
+    # foo/bar is unconditionally removed
 
-    assert (
-        f"{excinfo.value}"
-        == "unexpected archive structure: no component left to strip in bad"
-    )
+    assert [x for x in os.walk(dest)] == [
+        # dest/foo
+        (f"{dest}", [], ["foo"])
+    ]
 
 
 def test_unpack_strip_n_root(


### PR DESCRIPTION
redo of https://github.com/getsentry/devenv/pull/152 but I give up on trying to make sure a common prefix is stripped

gnu tar's behavior is just to unconditionally strip components so we'll just follow suit

i also rewrote the existing tests to actually have valid python tarfiles and also assert for file tree equality to be absolutely thorough