### PR TITLE
fix: unquote shell escaped parts of shims but keep $PATH quoted

### DIFF
--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -27,8 +27,8 @@ def _install(url: str, sha256: str, into: str) -> None:
     fs.write_script(
         f"{into}/gcloud",
         """#!/bin/sh
-export CLOUDSDK_PYTHON="{root}/python/bin/python3" \
-       PATH="{into}/google-cloud-sdk/bin:${{PATH}}"
+export CLOUDSDK_PYTHON={root}/python/bin/python3 \
+       PATH={into}/google-cloud-sdk/bin:\"${{PATH}}\"
 exec gcloud "$@"
 """,
         shell_escape={"root": root, "into": into},
@@ -36,8 +36,8 @@ exec gcloud "$@"
     fs.write_script(
         f"{into}/gsutil",
         """#!/bin/sh
-export CLOUDSDK_PYTHON="{root}/python/bin/python3" \
-       PATH="{into}/google-cloud-sdk/bin:${{PATH}}"
+export CLOUDSDK_PYTHON={root}/python/bin/python3 \
+       PATH={into}/google-cloud-sdk/bin:\"${{PATH}}\"
 exec gsutil "$@"
 """,
         shell_escape={"root": root, "into": into},

--- a/devenv/lib/gcloud.py
+++ b/devenv/lib/gcloud.py
@@ -28,7 +28,7 @@ def _install(url: str, sha256: str, into: str) -> None:
         f"{into}/gcloud",
         """#!/bin/sh
 export CLOUDSDK_PYTHON={root}/python/bin/python3 \
-       PATH={into}/google-cloud-sdk/bin:\"${{PATH}}\"
+       PATH={into}/google-cloud-sdk/bin:"${{PATH}}"
 exec gcloud "$@"
 """,
         shell_escape={"root": root, "into": into},
@@ -37,7 +37,7 @@ exec gcloud "$@"
         f"{into}/gsutil",
         """#!/bin/sh
 export CLOUDSDK_PYTHON={root}/python/bin/python3 \
-       PATH={into}/google-cloud-sdk/bin:\"${{PATH}}\"
+       PATH={into}/google-cloud-sdk/bin:"${{PATH}}"
 exec gsutil "$@"
 """,
         shell_escape={"root": root, "into": into},

--- a/devenv/lib/node.py
+++ b/devenv/lib/node.py
@@ -88,9 +88,9 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
         fs.write_script(
             f"{binroot}/{shim}",
             """#!/bin/sh
-export PATH="{binroot}/node-env/bin:${{PATH}}"
-export NPM_CONFIG_PREFIX="{binroot}/node-env"
-exec "{binroot}/node-env/bin/{shim}" "$@"
+export PATH={binroot}/node-env/bin:\"${{PATH}}\"
+export NPM_CONFIG_PREFIX={binroot}/node-env
+exec {binroot}/node-env/bin/{shim} "$@"
 """,
             shell_escape={"binroot": binroot, "shim": shim},
         )
@@ -137,8 +137,8 @@ def install_yarn(version: str, reporoot: str) -> None:
     fs.write_script(
         f"{binroot}/yarn",
         """#!/bin/sh
-export PATH="{binroot}/node-env/bin:${{PATH}}"
-exec "{binroot}/node-env/bin/yarn" "$@"
+export PATH={binroot}/node-env/bin:\"${{PATH}}\"
+exec {binroot}/node-env/bin/yarn "$@"
 """,
         shell_escape={"binroot": binroot},
     )

--- a/devenv/lib/node.py
+++ b/devenv/lib/node.py
@@ -88,7 +88,7 @@ def install(version: str, url: str, sha256: str, reporoot: str) -> None:
         fs.write_script(
             f"{binroot}/{shim}",
             """#!/bin/sh
-export PATH={binroot}/node-env/bin:\"${{PATH}}\"
+export PATH={binroot}/node-env/bin:"${{PATH}}"
 export NPM_CONFIG_PREFIX={binroot}/node-env
 exec {binroot}/node-env/bin/{shim} "$@"
 """,
@@ -137,7 +137,7 @@ def install_yarn(version: str, reporoot: str) -> None:
     fs.write_script(
         f"{binroot}/yarn",
         """#!/bin/sh
-export PATH={binroot}/node-env/bin:\"${{PATH}}\"
+export PATH={binroot}/node-env/bin:"${{PATH}}"
 exec {binroot}/node-env/bin/yarn "$@"
 """,
         shell_escape={"binroot": binroot},

--- a/devenv/lib/tenv.py
+++ b/devenv/lib/tenv.py
@@ -33,24 +33,24 @@ def _install(url: str, sha256: str, into: str) -> None:
     fs.write_script(
         f"{into}/tenv",
         """#!/bin/sh
-export TENV_ROOT="{TENV_ROOT}"
-exec "{TENV_ROOT}/bin/tenv" "$@"
+export TENV_ROOT={TENV_ROOT}
+exec {TENV_ROOT}/bin/tenv "$@"
 """,
         shell_escape={"TENV_ROOT": TENV_ROOT},
     )
     fs.write_script(
         f"{into}/terraform",
         """#!/bin/sh
-export TENV_ROOT="{TENV_ROOT}"
-exec "{TENV_ROOT}/bin/terraform" "$@"
+export TENV_ROOT={TENV_ROOT}
+exec {TENV_ROOT}/bin/terraform "$@"
 """,
         shell_escape={"TENV_ROOT": TENV_ROOT},
     )
     fs.write_script(
         f"{into}/terragrunt",
         """#!/bin/sh
-export TENV_ROOT="{TENV_ROOT}"
-exec "{TENV_ROOT}/bin/terragrunt" "$@"
+export TENV_ROOT={TENV_ROOT}
+exec {TENV_ROOT}/bin/terragrunt "$@"
 """,
         shell_escape={"TENV_ROOT": TENV_ROOT},
     )


### PR DESCRIPTION
f/u to https://github.com/getsentry/devenv/pull/154/commits/8ee991f624ba08115214ed6f793ccb7a3b7cfd83 for the remaining shims

additionally, quotes are now needed around `${{PATH}}` so it becomes `"${PATH}"` after str.format
