### PR TITLE
fix: venv.ensure checks for python existence

### DIFF
--- a/devenv/lib/venv.py
+++ b/devenv/lib/venv.py
@@ -15,32 +15,6 @@ VenvStatus = Enum(
 )
 
 
-# example venv configuration section:
-#
-# [venv.sentry-kube]
-# python = 3.11.6
-# requirements = k8s/cli/requirements.txt
-# path = optional
-# editable =
-#   k8s/cli
-#   k8s/cli/libsentrykube
-# bins =
-#   sentry-kube
-#   sentry-kube-pop
-#
-# [venv.salt]
-# python = 3.10.13
-# requirements = salt/requirements.txt
-# bins =
-#   salt-ssh
-#   ...
-#
-# example usage:
-#
-# venv_dir, python_version, requirements, editable_paths, bins = get(reporoot, "sentry-kube")
-# url, sha256 = config.get_python(reporoot, python_version)
-# ensure(path, python_version, url, sha256)
-# sync(reporoot, venv_dir, requirements, editable_paths, bins)
 def get(
     reporoot: str, name: str
 ) -> tuple[str, str, str, Optional[tuple[str, ...]], Optional[tuple[str, ...]]]:
@@ -103,6 +77,11 @@ def sync(
 
 
 def check(venv: str, python_version: str) -> VenvStatus:
+    try:
+        os.stat(f"{venv}/bin/python")
+    except FileNotFoundError:
+        return VenvStatus.NOT_PRESENT
+
     if not os.path.exists(f"{venv}/pyvenv.cfg"):
         return VenvStatus.NOT_PRESENT
 

--- a/tests/lib/test_venv.py
+++ b/tests/lib/test_venv.py
@@ -44,7 +44,7 @@ def test_get_ensure(tmp_path: pathlib.Path) -> None:
     venv_dir, python_version, requirements, editable_paths, bins = venv.get(
         repo.path, "sentry-kube"
     )
-    os.makedirs(venv_dir)
+    os.makedirs(f"{venv_dir}/bin")
 
     assert (venv_dir, python_version, requirements, editable_paths, bins) == (
         f"{repo.path}/.venv-sentry-kube",
@@ -71,6 +71,12 @@ def test_get_ensure(tmp_path: pathlib.Path) -> None:
     # fake venv
     with open(f"{venv_dir}/pyvenv.cfg", "w") as f:
         f.write(f"version = {python_version}\n")
+
+    # venv_dir/bin/python isn't present yet since we mocked that out
+    assert venv.check(venv_dir, python_version) == venv.VenvStatus.NOT_PRESENT
+
+    with open(f"{venv_dir}/bin/python", "w"):
+        pass
 
     assert venv.check(venv_dir, python_version) == venv.VenvStatus.OK
 


### PR DESCRIPTION
closes https://github.com/getsentry/devenv/issues/155

also removes an outdated example (repo readme is better and more visible)