### PR TITLE
feat: require minimum devenv version for a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,26 @@ Everything devenv needs is in `~/.local/share/sentry-devenv`.
     - this venv exclusively uses a python at `~/.local/share/sentry-devenv/python`
 
 
-### configuration
+### global configuration
 
-global configuration is at `~/.config/sentry-devenv/config.ini`.
+`~/.config/sentry-devenv/config.ini`
+```ini
+[devenv]
+# the parent directory of all devenv-managed repos
+coderoot = ~/code
+```
 
-repository configuration is at `[reporoot]/devenv/config.ini`.
+
+### repository configuration
+
+`[reporoot]/devenv/config.ini`
+```ini
+[devenv]
+# optionally require a minimum version to run sync.py
+minimum_version = 1.11.0
+```
+
+There are plenty more sections, their use is best seen in the [examples](#examples).
 
 
 ## examples

--- a/devenv/lib/repository.py
+++ b/devenv/lib/repository.py
@@ -42,10 +42,10 @@ class Repository:
         except KeyError:
             return
 
-        min_major, min_minor, min_patch = map(int, minimum_version.split("."))
-        major, minor, patch = map(int, version.split("."))
+        parsed_version = tuple(map(int, version.split(".")))
+        parsed_minimum_version = tuple(map(int, minimum_version.split(".")))
 
-        if (major, minor, patch) < (min_major, min_minor, min_patch):
+        if parsed_version < parsed_minimum_version:
             raise SystemExit(
                 f"""
 Your devenv version ({version}) doesn't meet the

--- a/devenv/lib/repository.py
+++ b/devenv/lib/repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib
 import os.path
 from configparser import ConfigParser
 
+from devenv import constants
 from devenv.lib.config import get_config
 from devenv.lib.fs import ensure_binroot
 
@@ -30,3 +32,29 @@ class Repository:
 
     def config(self) -> ConfigParser:
         return get_config(f"{self.config_path}/config.ini")
+
+    def check_minimum_version(self) -> None:
+        version = importlib.metadata.version("sentry-devenv")
+
+        cfg = self.config()
+        try:
+            minimum_version = cfg["devenv"]["minimum_version"]
+        except KeyError:
+            return
+
+        min_major, min_minor, min_patch = map(int, minimum_version.split("."))
+        major, minor, patch = map(int, version.split("."))
+
+        if (major, minor, patch) < (min_major, min_minor, min_patch):
+            raise SystemExit(
+                f"""
+Your devenv version ({version}) doesn't meet the
+minimum version ({minimum_version}) defined in the repo config.
+
+Run the following to update your global devenv to the minimum,
+and use it to run this repo's sync.
+
+{constants.root}/bin/devenv update {minimum_version}
+{constants.root}/bin/devenv sync
+"""
+            )

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -19,6 +19,8 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
         print(f"{repo.config_path}/sync.py not found!")
         return 1
 
+    repo.check_minimum_version()
+
     spec = importlib.util.spec_from_file_location(
         "sync", f"{repo.config_path}/sync.py"
     )

--- a/tests/lib/test_repository.py
+++ b/tests/lib/test_repository.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from devenv.lib.repository import Repository
+
+
+def test_check_minimum_version(tmp_path: str) -> None:
+    repo = Repository(f"{tmp_path}/repo")
+
+    mock_config = """
+[devenv]
+minimum_version = 1.11.0
+"""
+
+    os.makedirs(repo.config_path)
+    with open(f"{repo.config_path}/config.ini", "w") as f:
+        f.write(mock_config)
+
+    with patch("importlib.metadata.version", return_value="1.10.2"):
+        with pytest.raises(SystemExit):
+            repo.check_minimum_version()
+
+    with patch("importlib.metadata.version", return_value="1.11.0"):
+        repo.check_minimum_version()
+
+    with patch("importlib.metadata.version", return_value="1.11.1"):
+        repo.check_minimum_version()


### PR DESCRIPTION
sync now checks for an optionally defined minimum devenv version and recommends how to update the global devenv accordingly in order to use it to run sync to completion
