### PR TITLE
fix: also strip hardlink target

### DIFF
--- a/devenv/lib/archive.py
+++ b/devenv/lib/archive.py
@@ -103,6 +103,12 @@ def strip1(
                 continue
 
         member.path = member.path[i + 1 :]  # noqa: E203
+
+        # hardlink target (linkname) is relative to the root of the
+        # archive and must also be stripped
+        if member.islnk():
+            member.linkname = member.linkname[i + 1 :]  # noqa: E203
+
         yield member
 
 

--- a/tests/lib/test_archive.py
+++ b/tests/lib/test_archive.py
@@ -127,6 +127,28 @@ def tar4(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
+def tar5(tmp_path: pathlib.Path) -> pathlib.Path:
+    foo = tmp_path / "foo"
+    foo.mkdir()
+
+    foo_bar = tmp_path / "foo/bar"
+    foo_bar.write_text("")
+
+    foo_baz = tmp_path / "foo/baz"
+    foo_baz.hardlink_to(foo_bar)
+
+    tar = tmp_path / "tar"
+
+    with tarfile.open(tar, "w:tar") as tarf:
+        tarf.add(foo, arcname="foo")
+        # foo
+        # foo/bar
+        # foo/baz -> foo/bar
+
+    return tar
+
+
+@pytest.fixture
 def mock_sleep() -> typing.Generator[mock.MagicMock, None, None]:
     with mock.patch.object(time, "sleep", autospec=True) as mock_sleep:
         yield mock_sleep
@@ -285,4 +307,18 @@ def test_unpack_strip_n_root(
         # foo/bar
         (f"{dest2}", ["foo"], []),
         (f"{dest2}/foo", [], ["bar"]),
+    ]
+
+
+def test_unpack_strip_n_symlink(
+    tar5: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    dest = tmp_path / "dest"
+    archive.unpack_strip_n(str(tar5), str(dest), n=1)
+    # leading slash in /foo/bar doesn't count as a component
+
+    assert [*sorted_os_walk(dest)] == [
+        # bar
+        # baz (-> bar)
+        (f"{dest}", [], ["bar", "baz"])
     ]


### PR DESCRIPTION
discovered in https://github.com/getsentry/devenv/pull/170

fails on limactl linux x86-64 homebrew archive because `lima/0.23.2` needs to be stripped away

```
tarinfo = <TarInfo 'share/lima/templates/almalinux.yaml' at 0x7fdba9372e00>

    def _find_link_target(self, tarinfo):
        """Find the target member of a symlink or hardlink member in the
           archive.
        """
        if tarinfo.issym():
            # Always search the entire archive.
            linkname = "/".join(filter(None, (os.path.dirname(tarinfo.name), tarinfo.linkname)))
            limit = None
        else:
            # Search the archive before the link, because a hard link is
            # just a reference to an already archived file.
            linkname = tarinfo.linkname
            limit = tarinfo
    
        member = self._getmember(linkname, tarinfo=limit, normalize=True)
        if member is None:
>           raise KeyError("linkname %r not found" % linkname)
E           KeyError: "linkname 'lima/0.23.2/share/lima/templates/almalinux-9.yaml' not found"
```