### PR TITLE
feat: credsStore fix in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,10 @@ An exception to this would be python virtualenvs, which was implemented before t
 
 `devenv doctor`
 
-When you're inside a repository, this diagnoses and tries to fix common issues.
-Checks and fixes are defined in `[reporoot]/devenv/checks`.
+Use this to diagnose and fix common issues.
 
-`devenv nuke|uninstall` (wip)
-
-When you're inside a repository, this completely removes the dev environment.
+Repo-specific checks and fixes can be defined in `[reporoot]/devenv/checks`.
+Otherwise we have "builtin" checks and fixes in `devenv.checks`.
 
 
 ## technical overview

--- a/devenv/checks/credsStore.py
+++ b/devenv/checks/credsStore.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+
+from devenv.lib_check.types import checker
+from devenv.lib_check.types import fixer
+
+tags: set[str] = {"builtin"}
+name = "credsStore"
+
+
+@checker
+def check() -> tuple[bool, str]:
+    # When Docker Desktop is opened, it inserts "desktop" as the value
+    # for credsStore. This requires docker-credential-desktop which isn't
+    # generally installed. Most people don't need to login to docker anyways.
+    with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
+        config = json.loads(f.read())
+        if config.get("credsStore", "") == "desktop" and not shutil.which(
+            "docker-credential-desktop"
+        ):
+            return False, "credsStore requires nonexistent binary"
+
+    return True, ""
+
+
+@fixer
+def fix() -> tuple[bool, str]:
+    try:
+        with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
+            config = json.loads(f.read())
+            if config.get("credsStore"):
+                del config["credsStore"]
+
+        with open(os.path.expanduser("~/.docker/config.json"), "w") as f:
+            f.write(json.dumps(config))
+    except Exception as e:
+        return False, f"{e}"
+
+    return True, ""

--- a/devenv/checks/credsStore.py
+++ b/devenv/checks/credsStore.py
@@ -30,11 +30,11 @@ def check() -> tuple[bool, str]:
 def fix() -> tuple[bool, str]:
     try:
         with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
-            config = json.loads(f.read())
+            config = json.load(f)
             config.pop("credsStore", None)
 
         with open(os.path.expanduser("~/.docker/config.json"), "w") as f:
-            f.write(json.dumps(config))
+            json.dump(config, f)
     except Exception as e:
         return False, f"{e}"
 

--- a/devenv/checks/credsStore.py
+++ b/devenv/checks/credsStore.py
@@ -18,10 +18,11 @@ def check() -> tuple[bool, str]:
     # generally installed. Most people don't need to login to docker anyways.
     with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
         config = json.load(f)
-        if config.get("credsStore", "") == "desktop" and not shutil.which(
-            "docker-credential-desktop"
-        ):
-            return False, "credsStore requires nonexistent binary"
+
+    if config.get("credsStore", "") == "desktop" and not shutil.which(
+        "docker-credential-desktop"
+    ):
+        return False, "credsStore requires nonexistent binary"
 
     return True, ""
 
@@ -31,7 +32,8 @@ def fix() -> tuple[bool, str]:
     try:
         with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
             config = json.load(f)
-            config.pop("credsStore", None)
+
+        config.pop("credsStore", None)
 
         with open(os.path.expanduser("~/.docker/config.json"), "w") as f:
             json.dump(config, f)

--- a/devenv/checks/credsStore.py
+++ b/devenv/checks/credsStore.py
@@ -17,7 +17,7 @@ def check() -> tuple[bool, str]:
     # for credsStore. This requires docker-credential-desktop which isn't
     # generally installed. Most people don't need to login to docker anyways.
     with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
-        config = json.loads(f.read())
+        config = json.load(f)
         if config.get("credsStore", "") == "desktop" and not shutil.which(
             "docker-credential-desktop"
         ):
@@ -31,8 +31,7 @@ def fix() -> tuple[bool, str]:
     try:
         with open(os.path.expanduser("~/.docker/config.json"), "rb") as f:
             config = json.loads(f.read())
-            if config.get("credsStore"):
-                del config["credsStore"]
+            config.pop("credsStore", None)
 
         with open(os.path.expanduser("~/.docker/config.json"), "w") as f:
             f.write(json.dumps(config))

--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -99,7 +99,7 @@ def load_checks(repo: Repository, match_tags: set[str]) -> List[Check]:
         module_spec.loader.exec_module(module)
         try:
             check = Check(module)
-        except AssertionError as e:
+        except ValueError as e:
             print(f"⚠️ Skipping {module_name}: {e}")
             continue
         if match_tags and not check.tags.issuperset(match_tags):

--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -43,34 +43,36 @@ class Check:
     def __init__(self, module: ModuleType):
         # Check that the module has the required attributes.
         if not hasattr(module, "name"):
-            raise TypeError("missing the `name` attribute")
+            raise ValueError("missing the `name` attribute")
         if not isinstance(module.name, str):
-            raise TypeError("the `name` attribute should be a str")
+            raise ValueError("the `name` attribute should be a str")
         self.name = module.name
 
         if not hasattr(module, "tags"):
-            raise TypeError("missing the `tags` attribute")
+            raise ValueError("missing the `tags` attribute")
         if not isinstance(module.tags, set):
-            raise TypeError("the `tags` attribute should be a set")
+            raise ValueError("the `tags` attribute should be a set")
         self.tags = module.tags
 
         # Check that the module has the check and fix functions.
         if not hasattr(module, "check"):
-            raise TypeError("must have a `check` function")
+            raise ValueError("must have a `check` function")
         if not callable(module.check):
-            raise TypeError("the `check` attribute must be a function")
+            raise ValueError("the `check` attribute must be a function")
         check_hints = typing.get_type_hints(module.check)
         if not (check_hints["return"] == tuple[bool, str]):
-            raise TypeError("`check(...)` should return a tuple of (bool, str)")
+            raise ValueError(
+                "`check(...)` should return a tuple of (bool, str)"
+            )
         self.check = checker(module.check)
 
         if not hasattr(module, "fix"):
-            raise TypeError("must have a `fix` function")
+            raise ValueError("must have a `fix` function")
         if not callable(module.fix):
-            raise TypeError("the `fix` attribute should be a function")
+            raise ValueError("the `fix` attribute should be a function")
         fix_hints = typing.get_type_hints(module.fix)
         if not (fix_hints["return"] == tuple[bool, str]):
-            raise TypeError("`fix(...)` should return a tuple of (bool, str)")
+            raise ValueError("`fix(...)` should return a tuple of (bool, str)")
         self.fix = fixer(module.fix)
 
         super().__init__()
@@ -119,7 +121,7 @@ def load_builtin_checks(match_tags: set[str]) -> List[Check]:
         module = __import__(f"devenv.checks.{module_name}", fromlist=["_trash"])
         try:
             check = Check(module)
-        except TypeError as e:
+        except ValueError as e:
             print(f"⚠️ Skipping {module_name}: {e}")
             continue
         if match_tags and not check.tags.issuperset(match_tags):

--- a/devenv/doctor.py
+++ b/devenv/doctor.py
@@ -42,35 +42,35 @@ class Check:
 
     def __init__(self, module: ModuleType):
         # Check that the module has the required attributes.
-        assert hasattr(module, "name"), "missing the `name` attribute"
-        assert isinstance(
-            module.name, str
-        ), "the `name` attribute should be a str"
+        if not hasattr(module, "name"):
+            raise TypeError("missing the `name` attribute")
+        if not isinstance(module.name, str):
+            raise TypeError("the `name` attribute should be a str")
         self.name = module.name
 
-        assert hasattr(module, "tags"), "missing the `tags` attribute"
-        assert isinstance(
-            module.tags, set
-        ), "the `tags` attribute should be a set"
+        if not hasattr(module, "tags"):
+            raise TypeError("missing the `tags` attribute")
+        if not isinstance(module.tags, set):
+            raise TypeError("the `tags` attribute should be a set")
         self.tags = module.tags
 
         # Check that the module has the check and fix functions.
-        assert hasattr(module, "check"), "must have a `check` function"
-        assert callable(
-            module.check
-        ), "the `check` attribute must be a function"
+        if not hasattr(module, "check"):
+            raise TypeError("must have a `check` function")
+        if not callable(module.check):
+            raise TypeError("the `check` attribute must be a function")
         check_hints = typing.get_type_hints(module.check)
-        assert (
-            check_hints["return"] == tuple[bool, str]
-        ), "`check(...)` should return a tuple of (bool, str)"
+        if not (check_hints["return"] == tuple[bool, str]):
+            raise TypeError("`check(...)` should return a tuple of (bool, str)")
         self.check = checker(module.check)
 
-        assert hasattr(module, "fix"), "must have a `fix` function"
-        assert callable(module.fix), "the `fix` attribute should be a function"
+        if not hasattr(module, "fix"):
+            raise TypeError("must have a `fix` function")
+        if not callable(module.fix):
+            raise TypeError("the `fix` attribute should be a function")
         fix_hints = typing.get_type_hints(module.fix)
-        assert (
-            fix_hints["return"] == tuple[bool, str]
-        ), "`fix(...)` should return a tuple of (bool, str)"
+        if not (fix_hints["return"] == tuple[bool, str]):
+            raise TypeError("`fix(...)` should return a tuple of (bool, str)")
         self.fix = fixer(module.fix)
 
         super().__init__()
@@ -119,7 +119,7 @@ def load_builtin_checks(match_tags: set[str]) -> List[Check]:
         module = __import__(f"devenv.checks.{module_name}", fromlist=["_trash"])
         try:
             check = Check(module)
-        except AssertionError as e:
+        except TypeError as e:
             print(f"⚠️ Skipping {module_name}: {e}")
             continue
         if match_tags and not check.tags.issuperset(match_tags):


### PR DESCRIPTION
This implements the credsStore fix in doctor as a "builtin" command since it's not repo-specific.

I hope to add some more "builtin" checks and fixes soon since I want to recommend people try `devenv doctor` before proceeding with more specific troubleshooting. One idea is the detection of docker desktop running and killing it.

https://getsentry.atlassian.net/issues/DEVINFRA-475