### PR TITLE
ref: only update global devenv if it exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
+#!/not/executable/bash
+
 if [[ -f .env ]]; then
     dotenv .env
 fi

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -102,7 +102,7 @@ When done, hit ENTER to continue.
 Updating global tools (at {constants.root}/bin).
 """
     )
-    os.makedirs(f"{constants.root}/bin")
+    os.makedirs(f"{constants.root}/bin", exist_ok=True)
     brew.install()
     docker.install_global()
     direnv.install()

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -5,8 +5,7 @@ import os
 import shutil
 from collections.abc import Sequence
 
-from devenv.constants import CI
-from devenv.constants import EXTERNAL_CONTRIBUTOR
+from devenv import constants
 from devenv.lib import brew
 from devenv.lib import colima
 from devenv.lib import direnv
@@ -43,7 +42,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> ExitCode:
     default_config: Config = {"devenv": configs}
     initialize_config(context["config_path"], default_config)
 
-    if not CI and shutil.which("xcrun"):
+    if not constants.CI and shutil.which("xcrun"):
         # xcode-select --install will take a while,
         # and involves elevated permissions with a GUI,
         # so best to just let the user go through that separately then retrying,
@@ -61,23 +60,23 @@ def main(context: Context, argv: Sequence[str] | None = None) -> ExitCode:
 
     github.add_to_known_hosts()
 
-    if not EXTERNAL_CONTRIBUTOR and not github.check_ssh_access(
+    if not constants.EXTERNAL_CONTRIBUTOR and not github.check_ssh_access(
         # silence the error the first time since it's expected to happen
         silent=True
     ):
         is_employee = (
             False
-            if CI
+            if constants.CI
             else input("Are you a Sentry employee? (Y/n): ").lower()
             in {"y", "yes", ""}
         )
-        if not CI and not is_employee:
+        if not constants.CI and not is_employee:
             print(
                 "Please set the SENTRY_EXTERNAL_CONTRIBUTOR environment variable and re-run bootstrap."
             )
             return 1
         pubkey = github.generate_and_configure_ssh_keypair()
-        if not CI:
+        if not constants.CI:
             input(
                 f"""
 Failed to authenticate with an ssh key to GitHub.
@@ -97,8 +96,12 @@ When done, hit ENTER to continue.
                 "Still failing to authenticate to GitHub. ENTER to retry, otherwise ^C to quit."
             )
 
-    # Install global tools.
-    # Mirror this in update.py.
+    # Mirror this in bootstrap.py.
+    print(
+        f"""\
+Updating global tools in {constants.root}/bin
+"""
+    )
     brew.install()
     docker.install_global()
     direnv.install()

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -102,6 +102,7 @@ When done, hit ENTER to continue.
 Updating global tools (at {constants.root}/bin).
 """
     )
+    os.makedirs(f"{constants.root}/bin")
     brew.install()
     docker.install_global()
     direnv.install()

--- a/devenv/bootstrap.py
+++ b/devenv/bootstrap.py
@@ -99,7 +99,7 @@ When done, hit ENTER to continue.
     # Mirror this in bootstrap.py.
     print(
         f"""\
-Updating global tools in {constants.root}/bin
+Updating global tools (at {constants.root}/bin).
 """
     )
     brew.install()

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -35,7 +35,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 Updating global tools (at {constants.root}/bin).
 """
         )
-        os.makedirs(f"{constants.root}/bin")
+        os.makedirs(f"{constants.root}/bin", exist_ok=True)
         brew.install()
         docker.install_global()
         direnv.install()

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -32,7 +32,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
         # Mirror this in bootstrap.py.
         print(
             f"""\
-Updating global tools in {constants.root}/bin
+Updating global tools (at {constants.root}/bin).
 """
         )
         brew.install()
@@ -66,6 +66,7 @@ Updating global tools in {constants.root}/bin
 
         print(
             f"""\
+
 Global devenv at {constants.root}/bin/devenv updated.
 """
         )

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
+import os
 import sys
 from collections.abc import Sequence
 
@@ -19,30 +19,6 @@ module_help = "Updates global devenv and tools."
 
 
 def main(context: Context, argv: Sequence[str] | None = None) -> int:
-    if not sys.executable.startswith(f"{constants.root}/venv/bin/python"):
-        rc = subprocess.call((f"{constants.root}/bin/devenv", *sys.argv[1:]))
-        if rc != 0:
-            print(
-                """
-failed to update devenv!
-"""
-            )
-            return rc
-
-        print(
-            f"""
-The global devenv at {constants.root}/bin/devenv has been updated.
-
-You used a local (at {sys.executable}) devenv to do this,
-which has *not* been updated.
-
-If sync wasn't working before, try using global devenv to run it now:
-
-{constants.root}/bin/devenv sync
-"""
-        )
-        return 0
-
     parser = argparse.ArgumentParser()
     parser.add_argument("version", type=str, nargs="?")
     parser.add_argument(
@@ -53,8 +29,12 @@ If sync wasn't working before, try using global devenv to run it now:
 
     # This is so that people don't have to run update twice.
     if args.post_update:
-        # Reinstall/update global tools.
         # Mirror this in bootstrap.py.
+        print(
+            f"""\
+Updating global tools in {constants.root}/bin
+"""
+        )
         brew.install()
         docker.install_global()
         direnv.install()
@@ -62,33 +42,42 @@ If sync wasn't working before, try using global devenv to run it now:
         limactl.install_global()
         return 0
 
-    if args.version is None:
+    is_global_devenv = sys.executable.startswith(
+        f"{constants.root}/venv/bin/python"
+    )
+
+    global_devenv_exists = os.path.exists(f"{constants.root}/bin/devenv")
+
+    # even if we aren't the global devenv, we want to update
+    # the global devenv (but only if it exists) out of convenience
+    if is_global_devenv or global_devenv_exists:
+        if args.version is None:
+            version = "sentry-devenv"
+        else:
+            version = "sentry-devenv=={args.version}"
+
         proc.run(
-            (
-                f"{constants.root}/venv/bin/pip",
-                "install",
-                "-U",
-                "sentry-devenv",
-            ),
-            env={
-                # better than cli flag (who knows if it'll break in the future)
-                "PIP_DISABLE_PIP_VERSION_CHECK": "1"
-            },
-        )
-    else:
-        proc.run(
-            (
-                f"{constants.root}/venv/bin/pip",
-                "install",
-                f"sentry-devenv=={args.version}",
-            ),
+            (f"{constants.root}/venv/bin/pip", "install", "-U", version),
             env={
                 # better than cli flag (who knows if it'll break in the future)
                 "PIP_DISABLE_PIP_VERSION_CHECK": "1"
             },
         )
 
-    proc.run((f"{constants.root}/bin/devenv", "update", "--post-update"))
+        print(
+            f"""\
+Global devenv at {constants.root}/bin/devenv updated.
+"""
+        )
+
+    proc.run((sys.executable, "-P", "-m", "devenv", "update", "--post-update"))
+
+    if not is_global_devenv:
+        print(
+            """\
+To update the local devenv, you'll want to run `devenv sync`.
+"""
+        )
 
     return 0
 

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -35,6 +35,7 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 Updating global tools (at {constants.root}/bin).
 """
         )
+        os.makedirs(f"{constants.root}/bin")
         brew.install()
         docker.install_global()
         direnv.install()


### PR DESCRIPTION
Previously we tried to unconditionally update the global devenv but some people do not have it globally installed.

If local devenv update is run, it recommends running `devenv sync` but still updates the global tools.
