### PR TITLE
doc: Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Otherwise, set the `SENTRY_EXTERNAL_CONTRIBUTOR` environment variable.
 Download [this](https://raw.githubusercontent.com/getsentry/devenv/main/install-devenv.sh) and run it:
 
 ```
+curl https://raw.githubusercontent.com/getsentry/devenv/main/install-devenv.sh > install-devenv.sh
 bash install-devenv.sh
 ```
+
+Make sure to call this file `install-deven.sh` as the script calls itself when you run it.
 
 This "global" devenv is installed to `~/.local/share/sentry-devenv/bin/devenv`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl https://raw.githubusercontent.com/getsentry/devenv/main/install-devenv.sh >
 bash install-devenv.sh
 ```
 
-Make sure to call this file `install-deven.sh` as the script calls itself when you run it.
+Make sure to call this file `install-devenv.sh` as the script calls itself when you run it.
 
 This "global" devenv is installed to `~/.local/share/sentry-devenv/bin/devenv`.
 


### PR DESCRIPTION
This PR updates the install instructions:
- point out that the installation file must be called `install-devenv.sh` as it apparently calls itself while running
- add a curl command to the installation commands for ease of use

(I ran into this pitfall while going through the installation instructions, so I thought we might as well keep future users from making the same mistakes)