### PR TITLE
feat: install docker-buildx

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 managing dev environments since '24
 
 `devenv` is an extensible execution framework and library for authoring
-a simple set of high level commands - bootstrap, sync, doctor, nuke - that
+a simple set of high level commands - bootstrap, fetch, sync, doctor - that
 manage a repository's dev environment.
 
 ## prerequisites

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -100,7 +100,13 @@ def _check_buildx(binroot: str, expected_version: str) -> bool:
     # github.com/docker/buildx v0.22.0 Homebrew
     installed_version = stdout.strip().split()[1]
 
-    return installed_version == expected_version
+    if installed_version == expected_version:
+        return True
+
+    print(
+        f"installed docker-buildx {installed_version} is outdated! expected: {expected_version}"
+    )
+    return False
 
 
 def install_global() -> None:

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -139,12 +139,12 @@ def install_global() -> None:
             _install(
                 cfg[SYSTEM_MACHINE], cfg[f"{SYSTEM_MACHINE}_sha256"], binroot
             )
+    else:
+        _install(cfg[SYSTEM_MACHINE], cfg[f"{SYSTEM_MACHINE}_sha256"], binroot)
 
-            stdout = proc.run((f"{binroot}/docker", "--version"), stdout=True)
-            if f"Docker version {version}" not in stdout:
-                raise SystemExit(
-                    f"Failed to install docker {version}!\n\n{stdout}"
-                )
+    stdout = proc.run((f"{binroot}/docker", "--version"), stdout=True)
+    if f"Docker version {version}" not in stdout:
+        raise SystemExit(f"Failed to install docker {version}!\n\n{stdout}")
 
     if not _check_buildx(binroot, version_buildx):
         print(f"installing docker buildx {version_buildx}...")

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -86,9 +86,6 @@ def _install_buildx(url: str, sha256: str, into: str) -> None:
 
 
 def _check_buildx(binroot: str, expected_version: str) -> bool:
-    if not shutil.which("docker", path=binroot):
-        return False
-
     try:
         stdout = proc.run(
             (f"{binroot}/docker", "buildx", "version"), stdout=True
@@ -123,7 +120,7 @@ def install_global() -> None:
     version_buildx = "v0.22.0"
     cfg_buildx = {
         "darwin_x86_64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.darwin-amd64",
-        "darwin_x86_64_sha256": "5221ad6b8acd2283f8fbbeebc79ae4b657e83519ca1c1e4cfbb9405230b3d933 ",
+        "darwin_x86_64_sha256": "5221ad6b8acd2283f8fbbeebc79ae4b657e83519ca1c1e4cfbb9405230b3d933",
         "darwin_arm64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.darwin-arm64",
         "darwin_arm64_sha256": "5898c338abb1f673107bc087997dc3cb63b4ea66d304ce4223472f57bd8d616e",
         "linux_x86_64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.linux-amd64",

--- a/devenv/lib/docker.py
+++ b/devenv/lib/docker.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 from threading import Thread
 
+from devenv.constants import home
 from devenv.constants import root
 from devenv.constants import SYSTEM_MACHINE
 from devenv.lib import archive
@@ -55,7 +56,10 @@ def check_docker_to_host_connectivity(timeout: int = 3) -> bool:
 
 
 def uninstall(binroot: str) -> None:
-    for fp in (f"{binroot}/docker",):
+    for fp in (
+        f"{binroot}/docker",
+        f"{home}/.docker/cli-plugins/docker-buildx",
+    ):
         try:
             os.remove(fp)
         except FileNotFoundError:
@@ -76,15 +80,47 @@ def _install(url: str, sha256: str, into: str) -> None:
         os.replace(f"{tmpd}/docker", f"{into}/docker")
 
 
+def _install_buildx(url: str, sha256: str, into: str) -> None:
+    archive.download(url, sha256, dest=f"{into}/docker-buildx")
+
+
+def _check_buildx(binroot: str, expected_version: str) -> bool:
+    if not shutil.which("docker", path=binroot):
+        return False
+
+    try:
+        stdout = proc.run(
+            (f"{binroot}/docker", "buildx", "version"), stdout=True
+        )
+    except RuntimeError as e:
+        print(f"failed getting buildx version:\n\n{e}")
+        return False
+
+    # github.com/docker/buildx v0.22.0 Homebrew
+    installed_version = stdout.strip().split()[1]
+
+    return installed_version == expected_version
+
+
 def install_global() -> None:
     version = "27.3.1"
     cfg = {
-        "darwin_x86_64": "https://download.docker.com/mac/static/stable/x86_64/docker-27.3.1.tgz",
+        "darwin_x86_64": f"https://download.docker.com/mac/static/stable/x86_64/docker-{version}.tgz",
         "darwin_x86_64_sha256": "1b621d4c9a57ff361811cf29754aafb0c28bc113c70011927af8d73c2c162186",
-        "darwin_arm64": "https://download.docker.com/mac/static/stable/aarch64/docker-27.3.1.tgz",
+        "darwin_arm64": f"https://download.docker.com/mac/static/stable/aarch64/docker-{version}.tgz",
         "darwin_arm64_sha256": "9dae125282116146b06eb777c2125ddda6c0468c0b9ad6c72a82edbc6783a77b",
-        "linux_x86_64": "https://download.docker.com/linux/static/stable/x86_64/docker-27.3.1.tgz",
+        "linux_x86_64": f"https://download.docker.com/linux/static/stable/x86_64/docker-{version}.tgz",
         "linux_x86_64_sha256": "9b4f6fe406e50f9085ee474c451e2bb5adb119a03591f467922d3b4e2ddf31d3",
+    }
+
+    version_buildx = "v0.22.0"
+    cfg_buildx = {
+        "darwin_x86_64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.darwin-amd64",
+        "darwin_x86_64_sha256": "5221ad6b8acd2283f8fbbeebc79ae4b657e83519ca1c1e4cfbb9405230b3d933 ",
+        "darwin_arm64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.darwin-arm64",
+        "darwin_arm64_sha256": "5898c338abb1f673107bc087997dc3cb63b4ea66d304ce4223472f57bd8d616e",
+        "linux_x86_64": f"https://github.com/docker/buildx/releases/download/{version_buildx}/buildx-{version_buildx}.linux-amd64",
+        "linux_x86_64_sha256": "805195386fba0cea5a1487cf0d47da82a145ea0a792bd3fb477583e2dbcdcc2f",
     }
 
     binroot = f"{root}/bin"
@@ -102,4 +138,17 @@ def install_global() -> None:
 
     stdout = proc.run((f"{binroot}/docker", "--version"), stdout=True)
     if f"Docker version {version}" not in stdout:
-        raise SystemExit(f"Failed to install docker {version}! Found: {stdout}")
+        raise SystemExit(f"Failed to install docker {version}!\n\n{stdout}")
+
+    if _check_buildx(binroot, version_buildx):
+        return
+
+    print(f"installing docker buildx {version_buildx}...")
+    _install(
+        cfg_buildx[SYSTEM_MACHINE],
+        cfg_buildx[f"{SYSTEM_MACHINE}_sha256"],
+        f"{home}/.docker/cli-plugins",
+    )
+
+    if not _check_buildx(binroot, version_buildx):
+        raise SystemExit(f"Failed to install docker buildx {version_buildx}!")


### PR DESCRIPTION
The global docker install doesn't come with buildx. We should install it - some local development expects buildx to be available. I was building gocd images and they use buildx.