### PR TITLE
feat(doctor): two stage fix for dns problems, and use external DNS servers

### DIFF
--- a/devenv/checks/limaDns.py
+++ b/devenv/checks/limaDns.py
@@ -22,13 +22,27 @@ def check() -> tuple[bool, str]:
         return False, "colima isn't up"
 
     try:
-        # afaict there's no other executable on the default vm
-        # that can do DNS resolution
         proc.run(
-            ("colima", "exec", "--", "curl", "--head", "ghcr.io"), stdout=True
+            (
+                "colima",
+                "exec",
+                "--",
+                "python3",
+                "-Su",
+                "-c",
+                """
+import socket
+
+try:
+    socket.getaddrinfo("ghcr.io", None)
+except socket.gaierror as e:
+    raise SystemExit(f"failed to resolve ghcr.io: {e}")
+""",
+            ),
+            stdout=True,
         )
     except RuntimeError as e:
-        return False, f"colima failed to resolve ghcr.io:\n{e}\n"
+        return False, f"{e}"
 
     return True, ""
 

--- a/devenv/checks/limaDns.py
+++ b/devenv/checks/limaDns.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+
+from devenv.lib import colima
+from devenv.lib import proc
+from devenv.lib_check.types import checker
+from devenv.lib_check.types import fixer
+
+tags: set[str] = {"builtin"}
+name = "limaDns"
+
+
+@checker
+def check() -> tuple[bool, str]:
+    # dns resolution can... stop working if colima's running
+    # and wifi changes to some other network that gives macos some
+    # weird nameservers
+
+    status = colima.check()
+    if status != colima.ColimaStatus.UP:
+        return False, "colima isn't up"
+
+    try:
+        # afaict there's no other executable on the default vm
+        # that can do DNS resolution
+        proc.run(
+            ("colima", "exec", "--", "curl", "--head", "ghcr.io"), stdout=True
+        )
+    except RuntimeError as e:
+        return False, f"colima failed to resolve ghcr.io:\n{e}\n"
+
+    return True, ""
+
+
+@fixer
+def fix() -> tuple[bool, str]:
+    status = colima.start()
+    if status == colima.ColimaStatus.UNHEALTHY:
+        return False, "colima started, but it's unhealthy"
+
+    try:
+        proc.run(
+            (
+                "colima",
+                "exec",
+                "--",
+                "sudo",
+                "systemctl",
+                "restart",
+                "systemd-resolved.service",
+            )
+        )
+    except RuntimeError as e:
+        print(
+            f"""
+failed to restart the vm's resolved:
+{e}
+
+we're going to try restarting colima
+"""
+        )
+        try:
+            proc.run(
+                (sys.executable, "-P", "-m", "devenv", "colima", "restart")
+            )
+        except RuntimeError as e:
+            return False, f"{e}"
+
+    return True, ""

--- a/devenv/checks/limaDns.py
+++ b/devenv/checks/limaDns.py
@@ -49,7 +49,8 @@ def fix() -> tuple[bool, str]:
                 "systemctl",
                 "restart",
                 "systemd-resolved.service",
-            )
+            ),
+            stdout=True,
         )
     except RuntimeError as e:
         print(

--- a/devenv/colima.py
+++ b/devenv/colima.py
@@ -18,6 +18,9 @@ def main(context: Context, argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
+    # TODO: in addition to returning 1 we should print colima logs
+    #       (and/or send to sentry)
+
     if args.command == "start":
         status = colima.start()
         if status == colima.ColimaStatus.UNHEALTHY:

--- a/devenv/lib/colima.py
+++ b/devenv/lib/colima.py
@@ -180,6 +180,17 @@ def start(restart: bool = False) -> ColimaStatus:
             "colima",
             "start",
             "--verbose",
+            # this effectively makes the vm's resolvectl status use:
+            # DNS Servers: 8.8.8.8 1.1.1.1 192.168.5.2
+            # https://lima-vm.io/docs/config/network/user/
+            # 192.168.5.2 is the host, accessible from the vm
+            # sometimes using only the host will result in dns breaking
+            # for any number of reasons (public wifi that gives you some weird dns server,
+            # tethering, vpn, what have you)
+            "--dns",
+            "8.8.8.8",
+            "--dns",
+            "1.1.1.1",
             # ideally we keep ~ ro, but currently the "default" vm
             # is shared across repositories, so for ease of use we'll let home rw
             f"--mount=/var/folders:w,/private/tmp/colima:w,{home}:w",


### PR DESCRIPTION
this adds a 2-stage fix for dns problems (first restarting systemd-resolved, then restarting colima itself)

and using external dns should long term fix this issue 

<s>i don't think this kind of problem is reportable or fixable upstream as the default with colima is just to use the host's dns resolution (which can break in any number of ways depending on what kind of network you connect to) - i could suggest for them to use a better default though?</s>

> i haven't been able to reproduce that^ but actually host dns works, its just the resolver is broken

```
josh@CTKP7QRX4L.local ~  $ colima exec sudo systemctl stop systemd-resolved.service                               0
josh@CTKP7QRX4L.local ~  $ ~/dev/devenv/.tox/py311/bin/devenv doctor                                              0
Running checks: credsStore, limaDns
    ✅ check: credsStore
    ❌ check: limaDnscolima failed to resolve ghcr.io:
Command `colima exec -- curl --head ghcr.io` failed! (code 1)
combined out:
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: ghcr.io
time="2025-04-16T10:51:52-07:00" level=fatal msg="exit status 6"




The following problems have been identified:
    ❌ limaDns
        Do you want to attempt to fix limaDns? (Y/n):
        ✅ fix: limaDns

Checking that fixes worked as expected...
    ✅ check: limaDns

Looks good to me now!
josh@CTKP7QRX4L.local ~  $ ~/dev/devenv/.tox/py311/bin/devenv doctor                                              0
Running checks: credsStore, limaDns
    ✅ check: credsStore
    ✅ check: limaDns

Looks good to me.
```