### PR TITLE
Adjust for indygreg/python-build-standalone -> astral-sh redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ editable =
   .
 
 [python3.12.3]
-darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8
-darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e
-linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6
-linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d
 ```
 
@@ -234,13 +234,13 @@ python = 3.12.3
 requirements = inhouse-tool/requirements-dev.txt
 
 [python3.12.3]
-darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8
-darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e
-linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6
-linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d
 ```
 

--- a/ci/devenv-bootstrap.sh
+++ b/ci/devenv-bootstrap.sh
@@ -63,13 +63,13 @@ editable =
 # bins =
 
 [python3.13.1]
-darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = 4c4dafe2d59bb58e8d3ad26af637b7ae9c8141bb79738966752976861bdb103d
-darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = bbfc96038d0b6922fd783f6eb2c9bf9abb648531d23d236bc1a0c16bdd061944
-linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = bb4696825039a2b5dc7fea2c6aeb085c89fd397016b44165ec73b4224ccc83e2
-linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = d37aef7bdf5c27f7d006918f7cedb31f4ba07c88f61baac4ffbe0bee6d4b5248
 
 [node]

--- a/ci/integration/repo/devenv/config.ini
+++ b/ci/integration/repo/devenv/config.ini
@@ -13,11 +13,11 @@ python = 3.11.6
 requirements = requirements.txt
 
 [python3.11.6]
-darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = 178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371
-darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = 916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990
-linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8
-linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -97,16 +97,16 @@ parseopt() {  # argument (and environment-var) processing
   SNTY_DEVENV_PY_VERSION="${SNTY_DEVENV_PY_VERSION:-3.11.4}"
 }
 
-# translate from uname output to indygreg release tags:
+# translate from uname output to astral release tags:
 # e.g. https://github.com/astral-sh/python-build-standalone/releases
-indygreg_os() {
+astral_os() {
   case "$OSTYPE" in
     darwin) echo apple-darwin ;;
     linux|linux-gnu) echo unknown-linux-gnu ;;
     *) echo '??' ;;
   esac
 }
-indygreg_cpu() {
+astral_cpu() {
   case "$CPUTYPE" in
     aarch64|arm64)
       echo aarch64 ;;
@@ -139,20 +139,20 @@ install_python() {
   release="$1"
   version="$2"
   platform="$OSTYPE-$CPUTYPE"
-  indygreg_platform="$(indygreg_cpu)-$(indygreg_os)"
+  astral_platform="$(astral_cpu)-$(astral_os)"
 
-  case "$indygreg_platform" in
+  case "$astral_platform" in
     aarch64-apple-darwin)      sha256=cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4;;
     x86_64-apple-darwin)       sha256=47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00;;
     x86_64-unknown-linux-gnu)  sha256=e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05;;
     aarch64-unknown-linux-gnu) sha256=2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb;;
     *)
-      error "Unexpected platform; please ask in #discuss-dev-infra or contact <team-devenv@sentry.io>: ($platform -> $indygreg_platform)"
+      error "Unexpected platform; please ask in #discuss-dev-infra or contact <team-devenv@sentry.io>: ($platform -> $astral_platform)"
       ;;
   esac
 
 
-  tarball="cpython-$version+$release-$indygreg_platform-install_only.tar.gz"
+  tarball="cpython-$version+$release-$astral_platform-install_only.tar.gz"
   src="https://github.com/astral-sh/python-build-standalone/releases/download/$release/$tarball" \
   dst="$SNTY_DEVENV_CACHE/${tarball}"
   if check_checksum "$sha256" "$dst"; then

--- a/install-devenv.sh
+++ b/install-devenv.sh
@@ -98,7 +98,7 @@ parseopt() {  # argument (and environment-var) processing
 }
 
 # translate from uname output to indygreg release tags:
-# e.g. https://github.com/indygreg/python-build-standalone/releases
+# e.g. https://github.com/astral-sh/python-build-standalone/releases
 indygreg_os() {
   case "$OSTYPE" in
     darwin) echo apple-darwin ;;
@@ -153,7 +153,7 @@ install_python() {
 
 
   tarball="cpython-$version+$release-$indygreg_platform-install_only.tar.gz"
-  src="https://github.com/indygreg/python-build-standalone/releases/download/$release/$tarball" \
+  src="https://github.com/astral-sh/python-build-standalone/releases/download/$release/$tarball" \
   dst="$SNTY_DEVENV_CACHE/${tarball}"
   if check_checksum "$sha256" "$dst"; then
     echo "Using cached python download..."

--- a/tests/lib/test_venv.py
+++ b/tests/lib/test_venv.py
@@ -23,13 +23,13 @@ bins =
   sentry-kube-pop
 
 [python3.11.6]
-darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = 178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371
-darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = 916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990
-linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8
-linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec
 """
 


### PR DESCRIPTION
Appears https://github.com/indygreg/python-build-standalone redirecs now to https://github.com/astral-sh/python-build-standalone

Adjusted everything that matched.

There are still some other string matches, did not change these:

```
$ git grep indygreg
install-devenv.sh:# translate from uname output to indygreg release tags:
install-devenv.sh:indygreg_os() {
install-devenv.sh:indygreg_cpu() {
install-devenv.sh:  indygreg_platform="$(indygreg_cpu)-$(indygreg_os)"
install-devenv.sh:  case "$indygreg_platform" in
install-devenv.sh:      error "Unexpected platform; please ask in #discuss-dev-infra or contact <team-devenv@sentry.io>: ($platform -> $indygreg_platform)"
install-devenv.sh:  tarball="cpython-$version+$release-$indygreg_platform-install_only.tar.gz"
```