### PR TITLE
chore: Make `devenv` forward compatible with Sentry SDK 3.0.0

### DIFF
--- a/devenv/main.py
+++ b/devenv/main.py
@@ -103,7 +103,7 @@ def main() -> ExitCode:
         # https://sentry.sentry.io/settings/projects/sentry-dev-env/keys/
         dsn="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503",
         # enable performance monitoring
-        enable_tracing=True,
+        traces_sample_rate=1.0,
     )
 
     return devenv(sys.argv, f"{home}/.config/sentry-devenv/config.ini")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "typing_extensions",
-  "sentry-sdk==3.0.0a1",
+  "sentry-sdk",
 ]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "typing_extensions",
-  "sentry-sdk",
+  "sentry-sdk==3.0.0a1",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
The behavior stays the same. The deprecated `enable_tracing=True` sets `traces_sample_rate=1.0` internally.

See https://docs.sentry.io/platforms/python/migration/2.x-to-3.x#configuration