### PR TITLE
fix: update x.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ if using uv:
 
 `[reporoot]/devenv/sync.py`
 ```py
-from devenv.lib import uv
+from devenv.lib import config, uv
 
 def main(context: dict[str, str]) -> int:
     reporoot = context["reporoot"]
@@ -179,6 +179,9 @@ def main(context: dict[str, str]) -> int:
 
 `[reporoot]/devenv/config.ini`
 ```ini
+[devenv]
+minimum_version = 1.22.1
+
 [uv]
 darwin_arm64 = https://github.com/astral-sh/uv/releases/download/0.7.21/uv-aarch64-apple-darwin.tar.gz
 darwin_arm64_sha256 = c73af7a4e0bcea9b5b593a0c7e5c025ee78d8be3f7cd60bfeadc8614a16c92ef

--- a/devenv/update.py
+++ b/devenv/update.py
@@ -55,7 +55,7 @@ Updating global tools (at {constants.root}/bin).
         if args.version is None:
             version = "sentry-devenv"
         else:
-            version = "sentry-devenv=={args.version}"
+            version = f"sentry-devenv=={args.version}"
 
         proc.run(
             (f"{constants.root}/venv/bin/pip", "install", "-U", version),


### PR DESCRIPTION
i'm stupid

no one has really run into this because we have an alternate message in sentry devenv sync.py:

```
Hi! To reduce potential breakage we've defined a minimum
devenv version ({minimum_version}) to run sync.
Please run the following to update your global devenv:
devenv update
Then, use it to run sync this one time.
{constants.root}/bin/devenv sync
```