### PR TITLE
feat(doctor): ensure lima ssh credentials have correct permissions

### DIFF
--- a/devenv/checks/colimaSsh.py
+++ b/devenv/checks/colimaSsh.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from devenv import constants
+from devenv.lib import proc
+from devenv.lib_check.types import checker
+from devenv.lib_check.types import fixer
+
+tags: set[str] = {"builtin"}
+name = "colima ssh credentials should only be owner rw"
+
+
+def only_owner_can_rw(path: str) -> bool:
+    mode = os.stat(path).st_mode & 0o777
+    return mode == 0o400 or mode == 0o600
+
+
+@checker
+def check() -> tuple[bool, str]:
+    lima_ssh_creds = f"{constants.home}/.colima/_lima/_config/user"
+
+    if not only_owner_can_rw(lima_ssh_creds):
+        return (
+            False,
+            f"Permission bits on {lima_ssh_creds} are too permissive; colima startup will hang on waiting for ssh",
+        )
+
+    return True, ""
+
+
+@fixer
+def fix() -> tuple[bool, str]:
+    lima_ssh_creds = f"{constants.home}/.colima/_lima/_config/user"
+
+    os.chmod(lima_ssh_creds, 0o600)
+
+    try:
+        proc.run((sys.executable, "-P", "-m", "devenv", "colima", "start"))
+    except RuntimeError as e:
+        return (
+            False,
+            f"""Failed to start colima: {e}
+
+
+========================================================================================
+You might want to share the last 100 lines of colima's stderr log in #discuss-dev-infra:
+
+`tail -n 100 ~/.colima/_lima/colima/ha.stderr.log`
+""",
+        )
+
+    return True, ""


### PR DESCRIPTION
while i was away it seems lots of people have run into colima startup stalling on `[hostagent] Waiting for the essential requirement 2 of 2: "user session is ready for ssh"`

no one posted their `~/.colima/_lima/colima/ha.stderr.log` but i found that if `~/.colima/_lima/_config/user` (the ssh keypair used by the underlying lima VM) doesn't have the right permissions then lima's ssh will stall indefinitely:

```
{"level":"info","msg":"Waiting for the essential requirement 1 of 2: \"ssh\"","time":"2025-09-30T11:14:04-07:00"}
{"level":"debug","msg":"executing script \"ssh\"","time":"2025-09-30T11:14:04-07:00"}
{"level":"debug","msg":"executing ssh for script \"ssh\": /usr/bin/ssh [ssh -F /dev/null -o IdentityFile=\"/Users/josh/.colima/_lima/_config/user\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o GSSAPIAuthentication=no -o PreferredAuthentications=publickey -o Compression=no -o BatchMode=yes -o IdentitiesOnly=yes -o Ciphers=\"^aes128-gcm@openssh.com,aes256-gcm@openssh.com\" -o User=josh -o ControlMaster=auto -o ControlPath=\"/Users/josh/.colima/_lima/colima/ssh.sock\" -o ControlPersist=yes -p 53113 127.0.0.1 -- /bin/bash -c \"$(printf 'while read -r line; do [ -n \"$line\" ] \u0026\u0026 export \"$line\"; done\u003c\u003cEOF\\n$(sudo cat /mnt/lima-cidata/param.env)\\nEOF\\n/bin/bash')\"]","time":"2025-09-30T11:14:04-07:00"}
{"level":"debug","msg":"stdout=\"\", stderr=\"@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\\r\\n@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @\\r\\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\\r\\nPermissions 0644 for '/Users/josh/.colima/_lima/_config/user' are too open.\\r\\nIt is required that your private key files are NOT accessible by others.\\r\\nThis private key will be ignored.\\r\\nLoad key \\\"/Users/josh/.colima/_lima/_config/user\\\": bad permissions\\r\\nj
```