### PR TITLE
chore(docs): Make external contributor env var usage more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ manage a repository's dev environment.
 
 Are you a Sentry employee? Make sure your GitHub account has been added to a [`getsentry/engineering` team](https://github.com/orgs/getsentry/teams/engineering). If not, open an IT Ticket before continuing.
 
-Otherwise, set the `SENTRY_EXTERNAL_CONTRIBUTOR` environment variable.
+Otherwise, set the `SENTRY_EXTERNAL_CONTRIBUTOR` environment variable. You'll need this set for both `devenv bootstrap` and `devenv fetch`.
 
 ## install
 


### PR DESCRIPTION
It could be misconstrued that you only need to set the environment variable for the bootstrap stage (and the setting would persist).

This makes it more clear it needs to be set for both commands. I didn't think it was necessary to include an example on how to set an environment variable.